### PR TITLE
feat(linter): lint on commit

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,0 +1,4 @@
+#!/usr/bin/env sh
+. "$(dirname -- "$0")/_/husky.sh"
+
+yarn lint:all

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "lint:style": "stylelint",
     "lint:style:all": "lint:style \"src/**/*.{vue,scss}\"",
     "theo": "theo ./src/tokens/tokens.yml --transform web --format map.scss,scss,raw.json,json --dest ./src/assets/tokens",
-    "commit": "cz"
+    "commit": "cz",
+    "prepare": "husky install"
   },
   "keywords": [],
   "author": "",
@@ -70,6 +71,7 @@
     "eslint-plugin-vue": "^9.11.1",
     "eslint-webpack-plugin": "^4.0.1",
     "file-loader": "^6.2.0",
+    "husky": "^8.0.3",
     "jest": "^29.5.0",
     "jest-environment-jsdom": "^29.5.0",
     "jest-serializer-vue": "^3.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8066,6 +8066,11 @@ humanize-ms@^1.2.1:
   dependencies:
     ms "^2.0.0"
 
+husky@^8.0.3:
+  version "8.0.3"
+  resolved "https://registry.yarnpkg.com/husky/-/husky-8.0.3.tgz#4936d7212e46d1dea28fef29bb3a108872cd9184"
+  integrity sha512-+dQSyqPh4x1hlO1swXBiNb2HzTDN1I2IGLQx1GrBuiqFJfoMrnZWwVmatvSiO+Iz8fBUnf+lekwNo4c2LlXItg==
+
 iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"


### PR DESCRIPTION
Automatically lints on commit, and cancels the commit if an error is thrown.

![image](https://github.com/visitscotland/vs-component-library/assets/97949877/2dd2da67-af0d-4c01-a5ab-3db3cc17850d)

@markup-mitchell @GemmaLouise You'll need to yarn install to get husky for this, when you do it should automatically run the "prepare" script from package.json which will run "husky install" and connect up the githook for you. If it doesn't work (and lint on your next commit) then run that manually but hopefully it will, then it'll work out of the box for anyone who picks this up in the future and has to install to get storybook and stuff.