### PR TITLE
build(chromatic): only fire chromatic on PR creation/update

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -4,7 +4,17 @@
 name: 'Chromatic'
 
 # Event for the workflow
-on: push
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+    branches:
+      - 'main'
+
+  # Allows you to run this workflow manually from the Actions tab in the GitHub dashboard
+  workflow_dispatch: {}
 
 # List of jobs
 jobs:


### PR DESCRIPTION
It can still be manually invoked in the actions section if we want to check anything outside of the context of a PR, but it's most useful there as the changes it finds will be open for general review