### PR TITLE
fix(ssr): provide hydration friendly client entry for app

### DIFF
--- a/src/client-entry.js
+++ b/src/client-entry.js
@@ -1,35 +1,18 @@
 /* eslint-disable no-param-reassign */
 
-import { get, isObject } from 'lodash';
-
-import { Vue, initApp as initAppMain } from '@/main';
-
-const isServerRendered = (appMountTargetSelector) => {
-    const appContainer = document.querySelector(appMountTargetSelector);
-
-    return appContainer && appContainer.hasAttribute('data-server-rendered');
-};
+import {
+    Vue,
+    initApp as initAppMain,
+    initSSRApp as initSSRAppMain,
+} from '@/main';
 
 export { Vue };
 
-export const initApp = (options) => {
-    const appMountTargetSelector = get(options, 'el');
-    const hasBeenSSRed = isServerRendered(appMountTargetSelector);
+export const initApp = (options) => initAppMain(options);
 
-    if (appMountTargetSelector && hasBeenSSRed) {
-        if (!isObject(options)) {
-            options = {
+export const initSSRApp = (options) => {
+    const template = document.querySelector('#app-template').innerHTML;
+    options.template = template;
 
-            };
-        }
-
-        options.template = '#app-template';
-    }
-
-    if (hasBeenSSRed) {
-        // This fixes hydration mismatching because SSR does not preserve comments
-        options.comments = false;
-    }
-
-    return initAppMain(options);
+    return initSSRAppMain(options);
 };

--- a/ssr/ssr.js
+++ b/ssr/ssr.js
@@ -2,12 +2,21 @@ const { renderToString } = require('@vue/server-renderer');
 
 /** PLACEHOLDER: COMPONENT IMPORTS */
 
-const { initSSRApp } = require('@/main');
+const { initSSRApp, initApp } = require('@/main');
 
 const defaultVueOptions = {
     components: {
         /** PLACEHOLDER: COMPONENT REGISTRATION */
     },
+};
+
+export function createApp (options) {
+    const vueOptions = {
+        ...options,
+        ...defaultVueOptions,
+    };
+
+    return initApp(vueOptions, true);
 };
 
 export function createSSRApp (options) {


### PR DESCRIPTION
Adds support in the component library for the latest change to the "[component-library-ssr-integration]" branch, enabling front end hydration. I thought that was working before but we didn't have any components ported that actually relied on it so it wasn't clear. Recaptcha revealed that it wasn't, and it turns out the front end app also needs to be booted in ssr mode to hydrate now. With both changes here it now works properly, rendering on the back end then hydrating on the front end if JS is on

![Recaptcha](https://github.com/visitscotland/vs-component-library/assets/97949877/f3d44106-bae5-41bb-b37c-728ba76245c1)
