### PR TITLE
fix(video): ensure cookie init status sets to error if onetrust doesn't initiate

### DIFF
--- a/src/components/elements/video/Video.vue
+++ b/src/components/elements/video/Video.vue
@@ -180,7 +180,8 @@ export default {
         showError() {
             if ((!this.requiredCookiesExist
                 && this.cookiesInitStatus === true)
-                || this.cookiesInitStatus === 'error') {
+                || this.cookiesInitStatus === 'error'
+                || this.cookiesInitStatus === false) {
                 return true;
             }
 

--- a/src/mixins/verifyCookiesMixin.js
+++ b/src/mixins/verifyCookiesMixin.js
@@ -45,7 +45,7 @@ const cookieCheckerMixin = {
             // cookies being set declare an error
             if (this.timesRun > 50) {
                 clearStatusInterval(); // eslint-disable-line no-use-before-define
-                if (typeof this.onetrustActiveGroups === 'undefined') {
+                if (typeof this.onetrustActiveGroups === 'undefined' || this.cookiesInitStatus === null) {
                     this.cookiesInitStatus = 'error';
                 }
             } else if (this.cookiesSet.length > 0) {


### PR DESCRIPTION
This was failing to progress to error before, just sitting on null so the site wasn't showing the generic "onetrust didn't initiate, something's gone wrong" message. Not sure why that changed from vue2 to vue3 but this sorts it.