### PR TITLE
fix(third party): fix third party styles and build them in main script

### DIFF
--- a/build/third-party.webpack.conf.js
+++ b/build/third-party.webpack.conf.js
@@ -43,10 +43,6 @@ module.exports = {
                             importLoaders: 1,
                         },
                     },
-                    // Add browser prefixes and minify CSS.
-                    {
-                        loader: 'postcss-loader',
-                    },
                     // Load the SCSS/SASS
                     {
                         loader: 'sass-loader',

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
   "scripts": {
     "storybook": "storybook dev -p 6006",
     "build-storybook": "storybook build",
-    "build": "yarn theo && npm-run-all build:library build:ssr",
-    "build:dev": "yarn theo && npm-run-all build:library:dev build:ssr:dev",
+    "build": "yarn theo && npm-run-all build:library build:ssr third-party",
+    "build:dev": "yarn theo && npm-run-all build:library:dev build:ssr:dev third-party",
     "build:library": "cross-env NODE_ENV=production webpack --config ./build/webpack.conf.js",
     "build:library:dev": "cross-env NODE_ENV=development webpack --config ./build/webpack.conf.js",
     "build:ssr": "cross-env NODE_ENV=production webpack --config ./build/webpack.ssr.conf.js",


### PR DESCRIPTION
Adds the third party scripts to the build, hopefully that fixes some styling issues in the site, we might need to update a path to the file that side but can see after release.

Postcss-loader is I think no longer necessary, everything still seems to minify as expected with webpack 5