### PR TITLE
fix(webpack): use transpileOnly for ts modules in vue

### DIFF
--- a/build/webpack.conf.js
+++ b/build/webpack.conf.js
@@ -53,8 +53,14 @@ const webpackConfig = {
         rules: [
             {
                 test: /\.ts$/,
-                loader: 'ts-loader',
-                exclude: /node_modules/,
+                use: [
+                    {
+                        loader: 'ts-loader',
+                        options: {
+                            transpileOnly: true,
+                        },
+                    },
+                ],
             },
             {
                 test: /\.vue$/,

--- a/src/components/patterns/product-search/components/Autocomplete.vue
+++ b/src/components/patterns/product-search/components/Autocomplete.vue
@@ -3,7 +3,7 @@ import { ref, computed, watch, onMounted } from 'vue';
 import {default as slugify} from 'slugify';
 import TypeAhead from 'vue3-simple-typeahead';
 
-import type { TmsApiDataItem, Location } from '../../../../types.ts';
+import type { TmsApiDataItem, Location } from '../../../../types';
 
 const props = defineProps<{
     id: string,

--- a/src/components/patterns/product-search/components/DateRange.vue
+++ b/src/components/patterns/product-search/components/DateRange.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue';
-import { getLabelText } from '../../../../utils/lang.ts';
+import { getLabelText } from '../../../../utils/lang';
 import DateInput from './DateInput.vue';
 
 const props = defineProps({

--- a/src/components/patterns/product-search/components/GuestSelector.vue
+++ b/src/components/patterns/product-search/components/GuestSelector.vue
@@ -1,8 +1,8 @@
 <script setup lang="ts">
 import { ref } from 'vue';
-import { getLabelText } from '../../../../utils/lang.ts';
+import { getLabelText } from '../../../../utils/lang';
 import { v4 as uuidv4 } from 'uuid';
-import type { GuestUnit } from '../../../../types.ts';
+import type { GuestUnit } from '../../../../types';
 import GuestSelectorRow from './GuestSelectorRow.vue';
 
 import VsButton from '../../../elements/button/Button.vue';

--- a/src/components/patterns/product-search/components/GuestSelectorNumberGroup.vue
+++ b/src/components/patterns/product-search/components/GuestSelectorNumberGroup.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { onMounted, ref } from 'vue';
-import type { GuestNumberGroup } from '../../../../types.ts';
+import type { GuestNumberGroup } from '../../../../types';
 import VsButton from '../../../elements/button/Button.vue';
 
 const props = defineProps<{

--- a/src/components/patterns/product-search/components/GuestSelectorRow.vue
+++ b/src/components/patterns/product-search/components/GuestSelectorRow.vue
@@ -1,7 +1,7 @@
 <script setup lang="ts">
 import { computed, ref } from 'vue';
-import { getLabelText } from '../../../../utils/lang.ts';
-import type { GuestUnit } from '../../../../types.ts';
+import { getLabelText } from '../../../../utils/lang';
+import type { GuestUnit } from '../../../../types';
 import GuestSelectorNumberGroup from './GuestSelectorNumberGroup.vue';
 import VsButton from '../../../elements/button';
 

--- a/src/components/patterns/product-search/components/ProductSearchEmbed.vue
+++ b/src/components/patterns/product-search/components/ProductSearchEmbed.vue
@@ -157,10 +157,10 @@
 
 <script setup lang="ts">
 import { computed, ref, onMounted } from 'vue';
-import { getLabelText, getLocale } from '../../../../utils/lang.ts';
-import { baseUrl, paths, monthsEnglish } from '../../../../constants.ts';
-import { getProductTypes } from '../../../../utils/utils.ts';
-import { getData } from '../../../../utils/axios.ts';
+import { getLabelText, getLocale } from '../../../../utils/lang';
+import { baseUrl, paths, monthsEnglish } from '../../../../constants';
+import { getProductTypes } from '../../../../utils/utils';
+import { getData } from '../../../../utils/axios';
 import type { Location, TmsApiDataItem, SelectOption } from '../../../../types';
 
 import VsSelect from '../../../elements/select/Select.vue';

--- a/src/components/patterns/product-search/components/SelectInput.vue
+++ b/src/components/patterns/product-search/components/SelectInput.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref } from 'vue';
-import type { SelectOption } from '../../../../types.ts';
+import type { SelectOption } from '../../../../types';
 import Label from './Label.vue';
 
 const props = defineProps<{


### PR DESCRIPTION
This seems to get the build working, it's something to do with how vue-loader wants to handle typescript imports clashing with how ts-loader works. They were both trying to create separate files and vue-loader was failing to keep track of the file that it's supposed to be retrieving... or something along those lines. The stores seem to still build as expected into their own files in the dist folder and the product search components build properly

https://github.com/vuejs/vue-loader/issues/109#issuecomment-167385087

![image](https://github.com/visitscotland/vs-component-library/assets/97949877/e6d922ee-a989-4bfe-8301-e0da276068d9)
