### PR TITLE
feat(sticky nav): implement sticky meganav

### DIFF
--- a/src/styles/_global-styles.scss
+++ b/src/styles/_global-styles.scss
@@ -17,3 +17,13 @@ body {
 .zindex-fixed {
     z-index: $zindex-fixed;
 }
+
+.vs-sticky-nav {
+    position: sticky;
+    z-index: $zindex-fixed;
+    top: -28px;
+
+    @include media-breakpoint-up(md) {
+        top: -35px;
+    }
+}


### PR DESCRIPTION
This'll go on the wrapper class that sits above the meganav and the global nav in the freemarker, it makes the meganav always sticky at the top but lets the global nav scroll off the top

![image](https://github.com/visitscotland/vs-component-library/assets/97949877/21106c5f-0292-4e57-9ca9-d0061e82065a)

![image](https://github.com/visitscotland/vs-component-library/assets/97949877/adde02dd-76d7-4941-bdd0-b42f775a3773)
