### PR TITLE
feat(map): move bounding box north and south to contain Scotland

### DIFF
--- a/src/components/patterns/main-map-wrapper/components/MainMapWrapperMap.vue
+++ b/src/components/patterns/main-map-wrapper/components/MainMapWrapperMap.vue
@@ -786,8 +786,8 @@ export default {
             if (typeof this.boundsData === 'undefined'
                 || this.boundsData.type === 'undefined') {
                 boundingBox = [
-                    [-7.555827, 55.308836], // south-west point.
-                    [-0.778285, 60.830894], // north-east point.
+                    [-7.555827, 54.608836], // south-west point.
+                    [-0.778285, 60.880894], // north-east point.
                 ];
             } else if (this.boundsData.type === 'bounds') {
                 const southWest = new mapboxgl


### PR DESCRIPTION
This appears to have been set slightly too far north and south to actually show all of Scotland, increasing height or decreasing zoom still leaves the map trying to show this bounding box clipping off the top of Shetland and most of Galloway. It was set back in the previous project so I'm not entirely sure where the numbers came from but the behaviour now seems correct

Before

![image](https://github.com/visitscotland/vs-component-library/assets/97949877/d343c55c-d84f-4354-a3b9-0acca83d9e03)

After

![image](https://github.com/visitscotland/vs-component-library/assets/97949877/76c4c4d0-e3e4-46ba-809d-20c76e65a56e)
