### PR TITLE
chore(dependabot): bump get-func-name version

### DIFF
--- a/package.json
+++ b/package.json
@@ -195,6 +195,7 @@
     "json5": "^1.0.2",
     "word-wrap": "^1.2.4",
     "highlight.js": "^10.4.1",
-    "semver": "^7.5.4"
+    "semver": "^7.5.4",
+    "get-func-name": "^2.0.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -8723,10 +8723,10 @@ get-caller-file@^2.0.5:
   resolved "https://registry.yarnpkg.com/get-caller-file/-/get-caller-file-2.0.5.tgz#4f94412a82db32f36e3b0b9741f8a97feb031f7e"
   integrity sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==
 
-get-func-name@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.0.tgz#ead774abee72e20409433a066366023dd6887a41"
-  integrity sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==
+get-func-name@^2.0.0, get-func-name@^2.0.1:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/get-func-name/-/get-func-name-2.0.2.tgz#0d7cf20cd13fda808669ffa88f4ffc7a3943fc41"
+  integrity sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==
 
 get-intrinsic@^1.0.2, get-intrinsic@^1.1.1, get-intrinsic@^1.1.3, get-intrinsic@^1.2.0, get-intrinsic@^1.2.1:
   version "1.2.1"


### PR DESCRIPTION
This package comes from the PSW, so it's probably worth updating there as well but this forces a healthy resolution here and doesn't seem to cause any issues. Looks like it's already ^2.0.0 there so probably just needs a yarn install to bump the lock file