### PR TITLE
fix(webpack): stop hashing font file names

### DIFF
--- a/build/webpack.conf.js
+++ b/build/webpack.conf.js
@@ -125,7 +125,7 @@ const webpackConfig = {
                 test: /\.(woff2?|eot|ttf|otf)(\?.*)?$/,
                 type: 'asset/resource',
                 generator: {
-                    filename: buildMode === 'development' ? 'fonts/[name][ext]' : 'fonts/[name].[hash:7][ext]',
+                    filename: 'fonts/[name][ext]',
                 },
             },
             {


### PR DESCRIPTION
This seems to be the source of these console errors on .com. The font file names were being hashed when they were referenced in other files (like our css) but placed without hashes into the manifest, so when the preload tags were added to the page they were searching for the original name of the file and 404ing. That created those errors + probably degraded performance a little as the preloads weren't working.

![image](https://github.com/visitscotland/vs-component-library/assets/97949877/a815b00c-82ad-40cf-88df-9e464d285b75)

The hashing wasn't present in prod on the previous version of the component package and doesn't feel necessary, these files aren't changed regularly and need to be immediately cache busted to stop the site breaking when they're updated