### PR TITLE
fix(scss): fix abs() deprecation warning

### DIFF
--- a/src/assets/fontawesome/scss/_functions.scss
+++ b/src/assets/fontawesome/scss/_functions.scss
@@ -33,8 +33,8 @@
 
 @function fa-divide($dividend, $divisor, $precision: 10) {
   $sign: if($dividend > 0 and $divisor > 0, 1, -1);
-  $dividend: abs($dividend);
-  $divisor: abs($divisor);
+  $dividend: abs(#{$dividend});
+  $divisor: abs(#{$divisor});
   $quotient: 0;
   $remainder: $dividend;
   @if $dividend == 0 {


### PR DESCRIPTION
Fixes this 
![image](https://github.com/visitscotland/vs-component-library/assets/97949877/19c91e8a-2a00-4e53-88f8-5dd00d06d768)

This file doesn't get regularly updated with fontawesome, just variables.scss, so it shouldn't come back