### PR TITLE
336 psw location options being read aloud as blank

### DIFF
--- a/package.json
+++ b/package.json
@@ -136,6 +136,7 @@
     "webpack-node-externals": "^3.0.0"
   },
   "dependencies": {
+    "@headlessui/vue": "^1.7.22",
     "@mapbox/geojson-extent": "^1.0.1",
     "@storybook/test": "^8.0.10",
     "@vuelidate/core": "^2.0.2",
@@ -152,7 +153,6 @@
     "vue-recaptcha": "^2.0.1",
     "vue3-charts": "^1.1.33",
     "vue3-lazy-hydration": "^1.2.1",
-    "vue3-simple-typeahead": "^1.0.11",
     "youtube-vue3": "^0.1.15"
   },
   "peerDependencies": {

--- a/package.json
+++ b/package.json
@@ -136,7 +136,6 @@
     "webpack-node-externals": "^3.0.0"
   },
   "dependencies": {
-    "@headlessui/vue": "^1.7.22",
     "@mapbox/geojson-extent": "^1.0.1",
     "@storybook/test": "^8.0.10",
     "@vuelidate/core": "^2.0.2",
@@ -150,6 +149,7 @@
     "pinia": "^2.1.3",
     "uuid": "^9.0.0",
     "vue": "^3.3.4",
+    "vue-combo-blocks": "^2.1.1",
     "vue-recaptcha": "^2.0.1",
     "vue3-charts": "^1.1.33",
     "vue3-lazy-hydration": "^1.2.1",

--- a/src/components/product-search/components/Autocomplete.vue
+++ b/src/components/product-search/components/Autocomplete.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from 'vue';
-import TypeAhead from 'vue3-simple-typeahead';
+import { Combobox, ComboboxButton, ComboboxLabel, ComboboxInput, ComboboxOptions, ComboboxOption } from '@headlessui/vue';
+import VsIcon from '@/components/icon/Icon.vue';
 
 const props = defineProps<{
     id: string,
@@ -56,6 +57,18 @@ const showHiddenInput = computed(() => {
     return false;
 });
 
+
+const query = ref('');
+const defaultValue = computed(() => props.defaultVal ? props.defaultVal.name : '');
+
+const filteredOptions = computed(() => {
+    return query.value === ''
+        ? props.options
+        : props.options.filter((option) => {
+            return option[selectBy.value].toLowerCase().includes(query.value.toLowerCase());
+        })
+});
+
 watch(inputValue, (newInputVal) => {
     emit('changeValue', newInputVal);
 });
@@ -82,24 +95,39 @@ onMounted(() => {
 <template>
     <div 
         data-test="vs-autocomplete"
-        class="mb-4"
+        class="vs-autocomplete mb-4"
+        :id="id"
     >
-        <label :for="id">{{ label }}</label>
-        <TypeAhead
-            class="vs-input form-control"
-            :id="id"
-            :placeholder="placeholder"
-            :searchable="true"
-            :track-by="trackBy"
-            :valueProp="trackBy"
+        <Combobox
             v-model="inputValue"
-            autocomplete="off"
-            :items="options"
-            :minInputLength="0"
-            :itemProjection="(item) => item[selectBy]"        
-            @selectItem="updateValue"
-            :defaultItem="props.defaultVal"
-        />
+            :default-value="defaultValue"
+        >
+            <ComboboxLabel>
+                {{ label }}
+            </ComboboxLabel>
+            <ComboboxInput
+                @change="query = $event.target.value"
+                :display-value="(option: string) => option"
+                :placeholder="placeholder"
+                class="vs-input form-control"
+            />
+            <ComboboxButton>
+                <VsIcon 
+                    name="chevron-down"
+                    variant="primary"
+                    size="sm"
+                />
+            </ComboboxButton>
+            <ComboboxOptions>
+                <ComboboxOption
+                    v-for="(option, index) in filteredOptions"
+                    :key="index"
+                    :value="option[selectBy]"
+                >
+                    {{ option[selectBy] }}
+                </ComboboxOption>
+            </ComboboxOptions>
+        </Combobox>
 
         <!-- need to check inputValue length to ensure it's not an empty array -->
         <input
@@ -112,6 +140,42 @@ onMounted(() => {
 </template>
 
 <style lang="scss">
+.vs-autocomplete {
+    position: relative;
+
+    button {
+        background-color: $vs-color-background-input;
+        border: 0;
+        position: absolute;
+        right: $spacer-2;
+        bottom: $spacer-2;
+    }
+
+    ul {
+        background-color: $vs-color-background-input;
+        max-height: 250px;
+        overflow-y: scroll;
+        padding-left: 0;
+        position: absolute;
+        width: 100%;
+        z-index: 10;
+
+        li {
+            cursor: pointer;
+            font-size: $font-size-4;
+            list-style: none;
+            padding: $spacer-2 $spacer-4;
+
+            &:hover,
+            &[data-headlessui-state="active"],
+            &[data-headlessui-state="active selected"] {
+                background-color: $vs-color-background-primary;
+                color: $vs-color-text-inverse;
+            }
+        }
+    }
+}
+
     .simple-typeahead {
         position: relative;
 

--- a/src/components/product-search/components/Autocomplete.vue
+++ b/src/components/product-search/components/Autocomplete.vue
@@ -1,6 +1,6 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from 'vue';
-import { Combobox, ComboboxButton, ComboboxLabel, ComboboxInput, ComboboxOptions, ComboboxOption } from '@headlessui/vue';
+import VueComboBlocks from 'vue-combo-blocks';
 import VsIcon from '@/components/icon/Icon.vue';
 
 const props = defineProps<{
@@ -21,6 +21,30 @@ const emit = defineEmits<{
 }>()
 
 const inputValue = ref<string | string[]>([]); // init as empty array so as not to be undefined
+const filteredOptions = ref(props.options);
+
+const getOptionValue = (item) => item ? item[selectBy.value] : '';
+
+const updateOptions = (text) => {
+    filteredOptions.value = props.options.filter((item) =>
+        item[selectBy.value].toLowerCase().includes(text.toLowerCase())
+    );
+};
+
+const updateValue = (item) => {
+    if (typeof props.trackBy !== 'undefined') {
+        emit('changeValue', item[props.trackBy]);
+    } else {
+        emit('changeValue', item.label);
+    }
+}
+
+const selectBy = computed(() => {
+    if (typeof props.multiselectLabel !== 'undefined') {
+        return props.multiselectLabel;
+    }
+    return 'name';
+});
 
 const inputValueFormatted = computed(() => {
     if (typeof inputValue.value === 'string') {
@@ -32,43 +56,17 @@ const inputValueFormatted = computed(() => {
             }
         }
         return inputValue.value.trim();
+    } else if (typeof inputValue.value === 'object' && Object.keys(inputValue.value).length > 0) {
+        return getOptionValue(inputValue.value).trim();
     }
-});
-
-const selectBy = computed(() => {
-    if (typeof props.multiselectLabel !== 'undefined') {
-        return props.multiselectLabel;
-    }
-    return 'name';
+    return;
 });
 
 const showHiddenInput = computed(() => {
-    if (inputValue.value && inputValue.value.length > 0){
+    if (inputValueFormatted.value && inputValueFormatted.value.length > 0) {
         return true;
     }
     return false;
-});
-
-
-const query = ref('');
-const defaultValue = computed(() => props.defaultVal ? props.defaultVal.name : '');
-
-const filteredOptions = computed(() => {
-    return query.value === ''
-        ? props.options
-        : props.options.filter((option) => {
-            return option[selectBy.value].toLowerCase().includes(query.value.toLowerCase());
-        })
-});
-
-watch(inputValue, (newInputVal) => {
-    emit('changeValue', newInputVal);
-});
-
-watch(() => props.defaultVal, () => {
-    if (typeof props.defaultVal !== 'undefined') {
-        inputValue.value = props.defaultVal.name;
-    }
 });
 
 watch(() => inputValue.value, () => {
@@ -79,7 +77,7 @@ watch(() => inputValue.value, () => {
 
 onMounted(() => {
     if (typeof props.defaultVal !== 'undefined') {
-        inputValue.value = props.defaultVal.name;
+        inputValue.value = props.defaultVal;
     }
 });
 </script>
@@ -88,38 +86,63 @@ onMounted(() => {
     <div 
         data-test="vs-autocomplete"
         class="vs-autocomplete mb-4"
-        :id="id"
     >
-        <Combobox
+        <label :for="id">{{ label }}</label>
+        <VueComboBlocks
+            :input-id="id"
             v-model="inputValue"
-            :default-value="defaultValue"
+            :itemToString="getOptionValue"
+            :items="filteredOptions"
+            @input-value-change="updateOptions"
+            @select="updateValue"
+            v-slot="{
+                getInputProps,
+                getInputEventListeners,
+                hoveredIndex,
+                isOpen,
+                getMenuProps,
+                getMenuEventListeners,
+                getItemProps,
+                getItemEventListeners,
+                getComboboxProps,
+                openMenu,
+            }"
         >
-            <ComboboxLabel>
-                {{ label }}
-            </ComboboxLabel>
-            <ComboboxInput
-                @change="query = $event.target.value"
-                :display-value="(option: string) => option"
-                :placeholder="placeholder"
-                class="vs-input form-control"
-            />
-            <ComboboxButton>
+            <div
+                v-bind="getComboboxProps()"
+                class="vs-autocomplete__list-wrapper"
+            >
+                <input
+                    class="vs-input form-control"
+                    v-bind="getInputProps()"
+                    v-on="getInputEventListeners()"
+                    :placeholder="placeholder"
+                    @click="openMenu()"
+                />
                 <VsIcon 
                     name="chevron-down"
                     variant="primary"
                     size="sm"
                 />
-            </ComboboxButton>
-            <ComboboxOptions>
-                <ComboboxOption
-                    v-for="(option, index) in filteredOptions"
-                    :key="index"
-                    :value="option[selectBy]"
+                <ul
+                    v-show="isOpen"
+                    v-bind="getMenuProps()"
+                    v-on="getMenuEventListeners()"
+                    class="vs-autocomplete__list"
                 >
-                    {{ option[selectBy] }}
-                </ComboboxOption>
-            </ComboboxOptions>
-        </Combobox>
+                    <li
+                        v-for="(item, index) in filteredOptions"
+                        :key="item.id"
+                        v-bind="getItemProps({ item, index })"
+                        v-on="getItemEventListeners({ item, index })"
+                        class="vs-autocomplete__list-item"
+                        :class="{'vs-autocomplete__list-item--hover' : hoveredIndex === index }"
+                    >
+                        {{ item[selectBy] }}
+                    </li>
+                </ul>
+            </div>
+        </VueComboBlocks>
 
         <!-- need to check inputValue length to ensure it's not an empty array -->
         <input
@@ -134,16 +157,8 @@ onMounted(() => {
 <style lang="scss">
 .vs-autocomplete {
     position: relative;
-
-    button {
-        background-color: $vs-color-background-input;
-        border: 0;
-        position: absolute;
-        right: $spacer-2;
-        bottom: $spacer-2;
-    }
-
-    ul {
+    
+    &__list {
         background-color: $vs-color-background-input;
         max-height: 250px;
         overflow-y: scroll;
@@ -152,62 +167,28 @@ onMounted(() => {
         width: 100%;
         z-index: 10;
 
-        li {
+        &-wrapper {
+            position: relative;
+        }
+
+        &-item {
             cursor: pointer;
             font-size: $font-size-4;
             list-style: none;
             padding: $spacer-2 $spacer-4;
 
             &:hover,
-            &[data-headlessui-state="active"],
-            &[data-headlessui-state="active selected"] {
+            &--hover {
                 background-color: $vs-color-background-primary;
                 color: $vs-color-text-inverse;
             }
         }
     }
+
+    .vs-icon {
+        position: absolute;
+        top: calc(50% - $spacer-2);
+        right: $spacer-4;
+    }
 }
-
-    .simple-typeahead {
-        position: relative;
-
-        &-list {
-            position: absolute;
-            display: flex;
-            flex-direction: column;
-            max-height: 250px;
-            overflow-y: scroll;
-            background: #fff;
-            width: 100%;
-            z-index: 10;
-
-            &-item{
-                cursor: pointer;
-                font-size: $font-size-4;
-                padding: $spacer-2 $spacer-4;
-
-                &:hover{
-                    background-color: $vs-color-background-primary;
-                    color: $vs-color-text-inverse;
-                }
-            }
-        }
-
-        &-list-list 
-        &-list-list-item.simple-typeahead-list-item-active{
-            background-color: $vs-color-background-primary!important;
-            color: $vs-color-text-inverse!important;
-        }
-
-        &::after {
-            font-family: "Font Awesome Kit";
-            content: "\e06c";
-            display: inline-block;
-            position: absolute;
-            top: calc(50% - $spacer-3);
-            right: $spacer-4;
-            pointer-events: none;
-            color: $vs-color-icon-primary;
-        }
-    }    
 </style>

--- a/src/components/product-search/components/Autocomplete.vue
+++ b/src/components/product-search/components/Autocomplete.vue
@@ -33,15 +33,7 @@ const inputValueFormatted = computed(() => {
         }
         return inputValue.value.trim();
     }
-})
-
-const updateValue = (item) => {
-    if (typeof props.trackBy !== 'undefined') {
-        inputValue.value = item[props.trackBy];
-    } else {
-        inputValue.value = item.label;
-    }
-}
+});
 
 const selectBy = computed(() => {
     if (typeof props.multiselectLabel !== 'undefined') {

--- a/src/components/product-search/components/ProductSearchEmbed.vue
+++ b/src/components/product-search/components/ProductSearchEmbed.vue
@@ -163,8 +163,6 @@
     </div>
 </template>
 
-
- 
 <script lang="ts">
     //  Options API script block used to allow Vue 2 mixin to be used
     import { defineComponent } from "vue"; 

--- a/src/components/product-search/components/__tests__/Autocomplete.jest.spec.js
+++ b/src/components/product-search/components/__tests__/Autocomplete.jest.spec.js
@@ -25,21 +25,24 @@ const factoryMount = (propsData) => mount(VsAutocomplete, {
         name: 'loc',
         options: locationsData,
         placeholder: 'Enter a location',
+        trackBy: 'name',
         ...propsData,
     },
 });
 
 describe('VsAutocomplete', () => {
     it('should render a component with the data-test attribute `vs-autocomplete`', () => {
-        const wrapper = factoryShallowMount();
+        const wrapper = factoryMount();
         expect(wrapper.attributes('data-test')).toBe('vs-autocomplete');
     });
 
     it('updates the hidden input value on autocomplete value change', async() => {
         const wrapper = factoryMount();
 
-        await wrapper.find('.simple-typeahead-input').setValue('Aberdeen & Aberdeenshire');
-        expect(wrapper.find('input[name="loc"]').attributes('value')).toBe('Aberdeen & Aberdeenshire');
+        await wrapper.find('.vs-input').trigger('click');
+        await wrapper.find('li[id$="vue-combo-blocks-item-0"]').trigger('click');
+
+        expect(wrapper.find('input[name="loc"]').attributes('value')).toBe(locationsData[0].name);
     });
 
     it('updates the hidden input value on autocomplete value change if `isTourLocation` is true', async() => {
@@ -48,42 +51,50 @@ describe('VsAutocomplete', () => {
             options: toursOriginData,
         });
 
-        await wrapper.find('.simple-typeahead-input').setValue('Aberdeen & Aberdeenshire');
-        expect(wrapper.find('input[name="loc"]').attributes('value')).toBe('aberdeen-and-aberdeenshire');
+        await wrapper.find('.vs-input').trigger('click');
+        await wrapper.find('li[id$="vue-combo-blocks-item-0"]').trigger('click');
+
+        expect(wrapper.find('input[name="loc"]').attributes('value')).toBe(toursOriginData[0].name);
     });
 
     describe(':props', () => {
         it('renders the label with correct `ID` and `label` text', async() => {
-            const wrapper = factoryShallowMount();
+            const wrapper = factoryMount();
             const label = wrapper.find('label');
             expect(label.attributes('for')).toBe('search-location');
             expect(label.text()).toContain('Location');
         });
-        it('renders the autocomplete with correct `ID`', async() => {
-            const wrapper = factoryShallowMount();
-            const autocomplete = wrapper.find('vue3-simple-typeahead-stub');
-            expect(autocomplete.attributes('id')).toBe('search-location');
+        
+        it('renders the autocomplete input with correct `ID`', async () => {
+            const wrapper = factoryMount();
+            const autocompleteInput = wrapper.find('.vs-input');
+            expect(autocompleteInput.attributes('id')).toBe('search-location');
         });
+
         it('renders the autocomplete with correct `placeholder`', async() => {
-            const wrapper = factoryShallowMount();
-            const autocomplete = wrapper.find('vue3-simple-typeahead-stub');
-            expect(autocomplete.attributes('placeholder')).toBe('Enter a location');
+            const wrapper = factoryMount();
+            const autocompleteInput = wrapper.find('.vs-input');
+            expect(autocompleteInput.attributes('placeholder')).toBe('Enter a location');
         });
+
         it('sets a `defaultVal` when passed as a prop', async() => {
-            const wrapper = factoryShallowMount({
-                defaultVal: '4161',
+            const wrapper = factoryMount({
+                defaultVal: locationsData[0],
             });
-            const autocomplete = wrapper.find('vue3-simple-typeahead-stub');
-            expect(autocomplete.attributes('defaultitem')).toBe('4161');
+            await wrapper.vm.$nextTick();
+
+            expect(wrapper.find('input[name="loc"]').attributes('value')).toBe(locationsData[0].name);
         });
     });
 
     describe(':events', () => {
-        it('should emit a `changeValue` event when input value is changed', async() => {
+        it('should emit a `changeValue` event when input value is changed', async () => {
             const wrapper = factoryMount();
-            await wrapper.find('.simple-typeahead-input').setValue('Aberdeen & Aberdeenshire');
 
-            expect(wrapper.emitted('changeValue')[0][0]).toBe('Aberdeen & Aberdeenshire');
+            await wrapper.find('.vs-input').trigger('click');
+            await wrapper.find('li[id$="vue-combo-blocks-item-0"]').trigger('click');
+
+            expect(wrapper.emitted('changeValue')[0][0]).toBe(locationsData[0].name);
         });
     });
 });

--- a/yarn.lock
+++ b/yarn.lock
@@ -1950,17 +1950,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@headlessui/vue@npm:^1.7.22":
-  version: 1.7.22
-  resolution: "@headlessui/vue@npm:1.7.22"
-  dependencies:
-    "@tanstack/vue-virtual": "npm:^3.0.0-beta.60"
-  peerDependencies:
-    vue: ^3.2.0
-  checksum: 10c0/0e86ab60ac471ae36d60b05f365c7d707feb8884e4aea49875bd2b9d53ccfbd0001b2e18b5e7c2f88e9b535acd4dc58b461a046cde5ee70204cf53ec1e520889
-  languageName: node
-  linkType: hard
-
 "@humanwhocodes/config-array@npm:^0.11.14":
   version: 0.11.14
   resolution: "@humanwhocodes/config-array@npm:0.11.14"
@@ -3941,24 +3930,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@tanstack/virtual-core@npm:3.5.0":
-  version: 3.5.0
-  resolution: "@tanstack/virtual-core@npm:3.5.0"
-  checksum: 10c0/21a12049df81ce282054e8406cb74dd21d867aac077f31568ffdb08acd9aa171ae0666ceb43654895e73907acf5db02c7d651a66960da8acceeb2e034885e605
-  languageName: node
-  linkType: hard
-
-"@tanstack/vue-virtual@npm:^3.0.0-beta.60":
-  version: 3.5.0
-  resolution: "@tanstack/vue-virtual@npm:3.5.0"
-  dependencies:
-    "@tanstack/virtual-core": "npm:3.5.0"
-  peerDependencies:
-    vue: ^2.7.0 || ^3.0.0
-  checksum: 10c0/4e6f1a5cce660e42c822b34c24325d85c9ab6adb2c0acd7aea75821f25466de9338d84a4258732ede14d9ee538b45d2150a3f21d1c65a38ff3b88333dae67c5f
-  languageName: node
-  linkType: hard
-
 "@testing-library/dom@npm:^9.3.4":
   version: 9.3.4
   resolution: "@testing-library/dom@npm:9.3.4"
@@ -4660,7 +4631,6 @@ __metadata:
     "@babel/preset-env": "npm:^7.23.2"
     "@babel/preset-react": "npm:7.12.13"
     "@chromatic-com/storybook": "npm:^1.3.4"
-    "@headlessui/vue": "npm:^1.7.22"
     "@mapbox/geojson-extent": "npm:^1.0.1"
     "@originjs/vite-plugin-require-context": "npm:^1.0.9"
     "@rushstack/eslint-patch": "npm:^1.3.0"
@@ -4739,6 +4709,7 @@ __metadata:
     uuid: "npm:^9.0.0"
     vite: "npm:^5.2.10"
     vue: "npm:^3.3.4"
+    vue-combo-blocks: "npm:^2.1.1"
     vue-loader: "npm:^17.1.0"
     vue-recaptcha: "npm:^2.0.1"
     vue-style-loader: "npm:^4.1.3"
@@ -19536,6 +19507,15 @@ __metadata:
     "@mapbox/vector-tile": "npm:^1.3.1"
     pbf: "npm:^3.2.1"
   checksum: 10c0/a568801ae25f0ffe65ef697bf520c996c8a4067f73f355c0d5815238de90322c8ca207c61220206141cfe6f5b525de875b7eb26e22979a1b768b96d03b93dca7
+  languageName: node
+  linkType: hard
+
+"vue-combo-blocks@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "vue-combo-blocks@npm:2.1.1"
+  peerDependencies:
+    vue: ^3.2.25
+  checksum: 10c0/05d682b6b78b4bd75e2cc74bfe58fe983def601812dc98984bfa3e1e9c4153ab9dee15b1348f0be7e1a965aba6fd8231b0d53bc575ebe90679cb5e891b220a57
   languageName: node
   linkType: hard
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1950,6 +1950,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@headlessui/vue@npm:^1.7.22":
+  version: 1.7.22
+  resolution: "@headlessui/vue@npm:1.7.22"
+  dependencies:
+    "@tanstack/vue-virtual": "npm:^3.0.0-beta.60"
+  peerDependencies:
+    vue: ^3.2.0
+  checksum: 10c0/0e86ab60ac471ae36d60b05f365c7d707feb8884e4aea49875bd2b9d53ccfbd0001b2e18b5e7c2f88e9b535acd4dc58b461a046cde5ee70204cf53ec1e520889
+  languageName: node
+  linkType: hard
+
 "@humanwhocodes/config-array@npm:^0.11.14":
   version: 0.11.14
   resolution: "@humanwhocodes/config-array@npm:0.11.14"
@@ -3930,6 +3941,24 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tanstack/virtual-core@npm:3.5.0":
+  version: 3.5.0
+  resolution: "@tanstack/virtual-core@npm:3.5.0"
+  checksum: 10c0/21a12049df81ce282054e8406cb74dd21d867aac077f31568ffdb08acd9aa171ae0666ceb43654895e73907acf5db02c7d651a66960da8acceeb2e034885e605
+  languageName: node
+  linkType: hard
+
+"@tanstack/vue-virtual@npm:^3.0.0-beta.60":
+  version: 3.5.0
+  resolution: "@tanstack/vue-virtual@npm:3.5.0"
+  dependencies:
+    "@tanstack/virtual-core": "npm:3.5.0"
+  peerDependencies:
+    vue: ^2.7.0 || ^3.0.0
+  checksum: 10c0/4e6f1a5cce660e42c822b34c24325d85c9ab6adb2c0acd7aea75821f25466de9338d84a4258732ede14d9ee538b45d2150a3f21d1c65a38ff3b88333dae67c5f
+  languageName: node
+  linkType: hard
+
 "@testing-library/dom@npm:^9.3.4":
   version: 9.3.4
   resolution: "@testing-library/dom@npm:9.3.4"
@@ -4631,6 +4660,7 @@ __metadata:
     "@babel/preset-env": "npm:^7.23.2"
     "@babel/preset-react": "npm:7.12.13"
     "@chromatic-com/storybook": "npm:^1.3.4"
+    "@headlessui/vue": "npm:^1.7.22"
     "@mapbox/geojson-extent": "npm:^1.0.1"
     "@originjs/vite-plugin-require-context": "npm:^1.0.9"
     "@rushstack/eslint-patch": "npm:^1.3.0"
@@ -4714,7 +4744,6 @@ __metadata:
     vue-style-loader: "npm:^4.1.3"
     vue3-charts: "npm:^1.1.33"
     vue3-lazy-hydration: "npm:^1.2.1"
-    vue3-simple-typeahead: "npm:^1.0.11"
     webpack: "npm:^5.81.0"
     webpack-cli: "npm:^5.0.2"
     webpack-manifest-plugin: "npm:^5.0.0"
@@ -19692,15 +19721,6 @@ __metadata:
   peerDependencies:
     vue: ">=3.0.0"
   checksum: 10c0/2d70f6f3b16e7dd07edeac362e284fb2e307dc23715a283207e6f8e548f8d5e2076ccda58ce5da0fd4aa9a6813f301279b512850da902a39bb9f67d881d117f8
-  languageName: node
-  linkType: hard
-
-"vue3-simple-typeahead@npm:^1.0.11":
-  version: 1.0.11
-  resolution: "vue3-simple-typeahead@npm:1.0.11"
-  peerDependencies:
-    vue: ^3.0.5
-  checksum: 10c0/f12cca4d12444ff8356013947ada6442bcef1321dd5a939c02769fcd01b8abc2c5b9335ce8e7893df32c4dca39fd852c45594eaf0def22b6562f67a0870f61da
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
The `vue3-simple-typeahead`  component has an accessibility issue where the options are read out, by a screen reader, as "Blank" when using the keyboard to navigation through the list of options. I've replaced this component with a `@headlessui/vue` component, which is accessible.