### PR TITLE
Add npmPublishAccess setting

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -1,3 +1,3 @@
 nodeLinker: node-modules
-
+npmPublishAccess: public
 yarnPath: .yarn/releases/yarn-4.2.1.cjs


### PR DESCRIPTION
Add npmPublishAccess setting to the .yarnrc.yml - this setting is required for publishing the package to NPM