### PR TITLE
594 implement newsletter signup form using bloomreach engage

### DIFF
--- a/src/components/form/Form.vue
+++ b/src/components/form/Form.vue
@@ -95,6 +95,8 @@
                     </BFormGroup>
                 </fieldset>
 
+                <slot name="hidden-fields" />
+
                 <VsRecaptcha
                     @verified="onRecaptchaVerify"
                     :site-key="recaptchaKey"

--- a/src/components/form/__tests__/Form.jest.spec.js
+++ b/src/components/form/__tests__/Form.jest.spec.js
@@ -127,6 +127,7 @@ function mountOptions(propsData) {
             invalid: 'invalid text',
             submitting: 'submitting text',
             submitted: successContent,
+            'hidden-fields': '<input type="hidden" name="hidden" value="hidden" />',
         },
         propsData: {
             dataUrl: 'testUrl',
@@ -227,6 +228,13 @@ describe('VsForm', () => {
             await wrapper.vm.$nextTick();
 
             expect(wrapper.html()).toContain('error text');
+        });
+
+        it('should render the `hidden-fields` slot', async() => {
+            const wrapper = factoryShallowMount();
+            const hiddenField = wrapper.find('input[type=hidden][name=hidden]');
+
+            expect(hiddenField.exists()).toBe(true);
         });
     });
 

--- a/stories/Form.stories.js
+++ b/stories/Form.stories.js
@@ -28,7 +28,7 @@ const Template = (args) => ({
             >
                 <template
                     v-slot:hidden-fields
-                    v-if=args['hidden-fields']
+                    v-if="args['hidden-fields']"
                 >
                     <input
                         v-for="field in args['hidden-fields']"

--- a/stories/Form.stories.js
+++ b/stories/Form.stories.js
@@ -26,6 +26,18 @@ const Template = (args) => ({
             <VsForm
                 v-bind="args"
             >
+                <template
+                    v-slot:hidden-fields
+                    v-if=args['hidden-fields']
+                >
+                    <input
+                        v-for="field in args['hidden-fields']"
+                        type="hidden"
+                        :name="field.name"
+                        :value="field.value"
+                    />
+                </template>
+
                 <template v-slot:no-js v-if="args['no-js']">
                     <p>{{ args['no-js'] }}</p>
                 </template>
@@ -63,6 +75,24 @@ FEPL.args = {
     ...base,
     isMarketo: false,
     dataUrl: '/fixtures/forms/fepl-form-example.json',
+};
+
+export const HiddenFields = Template.bind({
+});
+
+HiddenFields.args = {
+    ...base,
+    isMarketo: false,
+    'hidden-fields': [
+        {
+            name: 'activity_description',
+            value: 'Website opt in for Snow Alerts (ski) and VS Email',
+        },
+        {
+            name: 'activity_source',
+            value: 'E-News Signups',
+        },
+    ],
 };
 
 export const ShowingConditionalField = Template.bind({


### PR DESCRIPTION
The new newsletter sign up form requires the use of hidden fields, the value of these fields are set within the CMS. I've added a slot to the form component to add these hidden fields to the form.