### PR TITLE
fix(typescript): fix declaration generation error with aliases

### DIFF
--- a/src/stores/video.store.ts
+++ b/src/stores/video.store.ts
@@ -16,7 +16,8 @@ type Video = {
 type VideoSet = {
     [key: string]: Video,
 }
-interface IVideosState {
+
+export interface IVideosState {
     videos: VideoSet,
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,5 +3,9 @@
     "allowJs": true,
     "outDir": "./dist",
     "esModuleInterop": true,
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"]
+    },
   },
 }


### PR DESCRIPTION
Those odd errors in the build for product search were coming from the type declaration generation stage of the vite export. That does mean they shouldn't have caused any concrete errors but they were making things marginally less type safe; and they were specific to the product search because it's the only set of components we have that are marked as being in typescript (although they're not very consistently typed) since their import from the external package.

The change to the tsconfig allows those to find things within the @ alias properly, and the change to the store fixes another issue which that then brought up with types in components using the video store