### PR TITLE
Feat/bootstrap vue next update

### DIFF
--- a/package.json
+++ b/package.json
@@ -164,7 +164,7 @@
     "@vuelidate/core": "^2.0.2",
     "@vuelidate/validators": "^2.0.2",
     "axios": "^1.4.0",
-    "bootstrap-vue-next": "^0.9.20",
+    "bootstrap-vue-next": "^0.17.0",
     "glob": "^8.1.0",
     "lodash": "^4.17.21",
     "mapbox-gl": "^1.11.1",

--- a/src/components/button/Button.vue
+++ b/src/components/button/Button.vue
@@ -369,10 +369,8 @@ export default {
         }
 
         &.vs-button--flex-reverse {
-            .btn-content {
-                display: flex;
-                flex-direction: row-reverse !important;
-            }
+            display: flex;
+            flex-direction: row-reverse !important;
         }
 
         /* Button Animation
@@ -409,7 +407,7 @@ export default {
         }
 
         &.button-flex,
-        &.button-flex .btn-content {
+        &.button-flex {
             display: flex;
         }
     }

--- a/src/components/dropdown/Dropdown.vue
+++ b/src/components/dropdown/Dropdown.vue
@@ -76,7 +76,7 @@ export default {
         }
     }
 
-    ~ .dropdown-menu {
+    .dropdown-menu {
         li {
             border-bottom: 1px solid $vs-color-border;
 

--- a/src/components/global-menu/components/GlobalMenuDropdown.vue
+++ b/src/components/global-menu/components/GlobalMenuDropdown.vue
@@ -103,7 +103,7 @@ export default {
         }
     }
 
-    ~ .dropdown-menu {
+    ~ .vs-global-menu__languages .dropdown-menu {
         min-width: auto;
         margin: 0;
         background: $vs-color-background-brand;
@@ -152,8 +152,12 @@ export default {
 }
 
 @include no-js {
-    .vs-global-menu__dropdown ~ .dropdown-menu li{
-        border-bottom: 0;
+    .vs-global-menu__dropdown ~ .vs-global-menu__languages .dropdown-menu {
+        position: relative !important;
+
+        li{
+            border-bottom: 0;
+        }
     }
 }
 

--- a/src/components/global-menu/components/GlobalMenuLanguage.vue
+++ b/src/components/global-menu/components/GlobalMenuLanguage.vue
@@ -90,7 +90,7 @@ export default {
 .vs-global-menu__languages {
     position: static;
 
-    ~ .dropdown-menu {
+    .dropdown-menu {
         width: 100%;
         background: $vs-color-background-brand;
         font-size: $font-size-2;
@@ -170,7 +170,7 @@ export default {
         display: block;
         width: 100%;
 
-        ~ .dropdown-menu {
+        .dropdown-menu {
             @extend .show;
             max-height: 700px;
             opacity: $opacity-100;

--- a/src/components/global-menu/components/GlobalMenuLanguageItem.vue
+++ b/src/components/global-menu/components/GlobalMenuLanguageItem.vue
@@ -65,7 +65,7 @@ export default {
 </script>
 
 <style lang="scss">
-.vs-dropdown ~ .dropdown-menu {
+.vs-dropdown .dropdown-menu {
     .vs-global-menu__languages__item {
         &:not(:last-of-type) {
             border-bottom: 1px solid $vs-color-border-inverse;

--- a/src/components/map-with-sidebar/components/MapWithSidebarCategory.vue
+++ b/src/components/map-with-sidebar/components/MapWithSidebarCategory.vue
@@ -110,7 +110,7 @@ export default {
         @include map-button-themes;
 
         &__button.vs-button.btn-transparent {
-            display: block!important;
+            display: flex !important;
             letter-spacing: normal;
             font-size: $font-size-5;
             font-weight: $font-weight-bold;
@@ -119,10 +119,7 @@ export default {
             text-align: left;
             padding: $spacer-4 $spacer-4;
             border: none;
-
-            .btn-content{
-                justify-content: space-between;
-            }
+            justify-content: space-between;
 
             .vs-icon--internal-link {
                 color: $vs-color-icon-tertiary;

--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -193,4 +193,10 @@ export default {
         display: block;
     }
 }
+
+.b-overlay {
+    .bg-dark {
+        background-color: rgba(0, 0, 0, 0.5);
+    }
+}
 </style>

--- a/src/components/social-share/SocialShare.vue
+++ b/src/components/social-share/SocialShare.vue
@@ -196,7 +196,7 @@ export default {
          * Closes popover on close button click
          */
         onClose(event) {
-            this.$refs.popover.hideFn(event);
+            this.$refs.popover.hide(event);
         },
         /**
          * When popover is shown, focuses on the first share button
@@ -279,8 +279,8 @@ export default {
             font-size: inherit;
             text-align: center;
             border: 0;
-            top: 60px !important;
-            left: unset !important;
+            top: 40px !important;
+            left: 20px !important;
             right: 10px;
 
             .popover-arrow {
@@ -316,7 +316,7 @@ export default {
             @include media-breakpoint-up(md) {
                 max-width: 600px;
                 width: 600px !important;
-                top: 60px !important;
+                top: 40px !important;
             }
 
             @include media-breakpoint-up(lg) {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1932,7 +1932,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@floating-ui/vue@npm:^1.0.1":
+"@floating-ui/vue@npm:^1.0.6":
   version: 1.0.6
   resolution: "@floating-ui/vue@npm:1.0.6"
   dependencies:
@@ -4799,7 +4799,7 @@ __metadata:
     babel-loader: "npm:^9.1.2"
     babel-plugin-macros: "npm:^2.4.2"
     bootstrap: "npm:^5.3.2"
-    bootstrap-vue-next: "npm:^0.9.20"
+    bootstrap-vue-next: "npm:^0.17.0"
     chromatic: "npm:^6.17.3"
     clean-webpack-plugin: "npm:^4.0.0"
     commitizen: "npm:^4.3.0"
@@ -5225,7 +5225,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@vueuse/core@npm:^10.2.1":
+"@vueuse/core@npm:^10.9.0":
   version: 10.10.0
   resolution: "@vueuse/core@npm:10.10.0"
   dependencies:
@@ -6744,15 +6744,15 @@ __metadata:
   languageName: node
   linkType: hard
 
-"bootstrap-vue-next@npm:^0.9.20":
-  version: 0.9.26
-  resolution: "bootstrap-vue-next@npm:0.9.26"
+"bootstrap-vue-next@npm:^0.17.0":
+  version: 0.17.6
+  resolution: "bootstrap-vue-next@npm:0.17.6"
   dependencies:
-    "@floating-ui/vue": "npm:^1.0.1"
-    "@vueuse/core": "npm:^10.2.1"
+    "@floating-ui/vue": "npm:^1.0.6"
+    "@vueuse/core": "npm:^10.9.0"
   peerDependencies:
-    vue: ^3.3.4
-  checksum: 10c0/9118ce9d3d09098766c3ea7de965af0f2cbc8151d7fae65762da99372ba55c96adc6329a1fb2fa2c438bd4db1834f74e8ba723a05811040835ea13688b2f07a8
+    vue: ^3.4.21
+  checksum: 10c0/f65561fdc210e0679514058561e564735536dc77103fbd9e80835d749a23b4c55774262fbfe156898d135bf8880abaf1cfd8c0be330a0fe2980b745cf3e1870d
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Follow up to the previous PR bumping Bootstrap Vue Next to v0.17.x . I think most of these changes are actually just reversing changes we had to make when we first switched from Bootstrap Vue to BVN so I guess they're more in line with how Bootstrap is supposed to work now