### PR TITLE
589 se product search results returning incorrect things to do results for dunfermline

### DIFF
--- a/src/components/product-search/components/ProductSearchEmbed.vue
+++ b/src/components/product-search/components/ProductSearchEmbed.vue
@@ -66,7 +66,7 @@
                                 v-if="selectedProd !== 'tour'"
                                 type="hidden"
                                 name="locprox"
-                                :value="chosenLocation?.type === 'DISTRICT' ? 1 : 0"
+                                value="0"
                             >
                             <input
                                 v-if="selectedProd !== 'tour' && chosenLocation?.type === 'DISTRICT'"


### PR DESCRIPTION
re #589

Set the `locprox` value to zero since the search results includes items that are outwith the expected search area (e.g. places in Kinross showing up when searching Dunfermline).