### PR TITLE
VS-62 Investigate drop off in mega nav analytics logged

### DIFF
--- a/src/utils/check-vendor-library.js
+++ b/src/utils/check-vendor-library.js
@@ -3,13 +3,12 @@
      * @param name {string} name - library to wait for
      * @param callback {function} - function to call if the library is loaded
      */
-const checkVendorLibrary = (name, callback) => {
-    const interval = 500;
+const checkVendorLibrary = (name, callback, interval = 0) => {
     window.setTimeout(() => {
         if (window[name]) {
             callback(window[name]);
         } else {
-            checkVendorLibrary(name, callback);
+            checkVendorLibrary(name, callback, 500);
         }
     }, interval);
 };


### PR DESCRIPTION
The `checkVendorLibrary` function has a 500ms delay. When there's a navigation event the new page can occasionally start loading during this delay so the event doesn't get added to the datalayer. I've set the initial timeout interval to zero so that the function runs instantly first time and then set the interval to 500ms when it loops.