### PR TITLE
VS-249 FED BREG Newsletter Form Subscribe Button Aria label incorrect

### DIFF
--- a/src/components/button/Button.vue
+++ b/src/components/button/Button.vue
@@ -1,14 +1,14 @@
 <template>
     <BButton
         :variant="variant"
-        :href="href"
-        :tabindex="tabindex"
+        :href="href || undefined"
+        :tabindex="tabindex || undefined"
         class="vs-button"
         :class="buttonClasses"
         :size="size"
         v-bind="$attrs"
         :aria-disabled="$attrs.disabled ? true : false"
-        :aria-label="iconOnly ? icon : false"
+        :aria-label="iconOnly ? icon : undefined"
         @click="animateHandler($event)"
         @keyup.tab="tabbedIn"
     >


### PR DESCRIPTION
Dynamic binding is done differently in Vue3, we need to set the attribute to `undefined` instead for `false`. I've updated the `aria-label`, `href`, and `tabindex` with this change.