### PR TITLE
fix(meganav): ensure that meganav remains on baseline if it overflows

### DIFF
--- a/src/components/mega-nav/MegaNav.vue
+++ b/src/components/mega-nav/MegaNav.vue
@@ -342,5 +342,9 @@ export default {
         flex: 0 0 100%;
         position: relative;
     }
+
+    .vs-mega-nav__main-row {
+        flex-wrap: wrap;
+    }
 }
 </style>

--- a/src/components/mega-nav/MegaNav.vue
+++ b/src/components/mega-nav/MegaNav.vue
@@ -11,7 +11,7 @@
                 class="h-100"
             >
                 <VsRow
-                    class="align-items-center h-100"
+                    class="align-items-center h-100 vs-mega-nav__main-row"
                 >
                     <!-- Logo Link -->
                     <VsCol
@@ -278,6 +278,10 @@ export default {
 
     @include media-breakpoint-up(lg) {
         height: 55px;
+    }
+
+    &__main-row {
+        flex-wrap: nowrap;
     }
 
     &__logo {


### PR DESCRIPTION
Fixes a minor visual bug on business events, the search isn't present and there's an extra nav entry to fill the same space, but the empty search/mobile container overlaps onto the next row and pushes everything out of alignment. This brings it back in and should ensure that any similar issues in the future at least look right.