### PR TITLE
feat(spacing.yml tokens and utils): add spacing tokens in new format

### DIFF
--- a/src/styles/_bootstrap-overrides.scss
+++ b/src/styles/_bootstrap-overrides.scss
@@ -56,7 +56,24 @@ $container-max-widths: (
 
 /* Spacing */
 $spacers: (
-    0: $spacer-0,
+    // Utility classes are generated with the corresponding suffixes eg mt-075 = 0.75rem, (replacing mt-3)
+    "0": $spacer-0,
+    "0125": $spacer-0125,
+    "050": $spacer-050,
+    "075": $spacer-075,
+    "100": $spacer-100,
+    "125": $spacer-125,
+    "150": $spacer-150,
+    "175": $spacer-175,
+    "200": $spacer-200,
+    "250": $spacer-250,
+    "300": $spacer-300,
+    "400": $spacer-400,
+    "500": $spacer-500,
+    "600": $spacer-600,
+    "700": $spacer-700,
+    // spacer-1 - spacer-12 to be deprecated
+    // retained until v4 (?) for backwards compatibility
     1: $spacer-1,
     2: $spacer-2,
     3: $spacer-3,

--- a/src/styles/_bootstrap-overrides.scss
+++ b/src/styles/_bootstrap-overrides.scss
@@ -88,6 +88,8 @@ $spacers: (
     12: $spacer-12,
 );
 
+@warn "`$spacer-1` to `$spacer-12` and derivative utility classes (`mt-3`, `pb-4` etc) are deprecated in the VS design system. Replace the `$spacer-` suffix that represents the correct rem size. https://visitscotland.atlassian.net/wiki/spaces/DE/pages/edit-v2/211943505?draftShareId=ffaf70b8-e842-4db9-b780-25443f12d430#%5BmediaInline%5D--Deprecated-spacer-tokens";
+
 
 /* Borders */
 $border-color: $vs-color-border;

--- a/src/tokens/spacing.yml
+++ b/src/tokens/spacing.yml
@@ -5,10 +5,42 @@
 props:
   - name: spacer-0
     value: "0"
+  - name: spacer-0125
+    value: "0.125rem"
+  - name: spacer-025
+    value: "0.25rem"
+  - name: spacer-050
+    value: "0.5rem"
+  - name: spacer-075
+    value: "0.75rem"
+  - name: spacer-100
+    value: "1rem"
+  - name: spacer-125
+    value: "1.25rem"
+  - name: spacer-150
+    value: "1.5rem"
+  - name: spacer-175
+    value: "1.75rem"
+  - name: spacer-200
+    value: "2rem"
+  - name: spacer-250
+    value: "2.5rem"
+  - name: spacer-300
+    value: "3rem"
+  - name: spacer-400
+    value: "4rem"
+  - name: spacer-500
+    value: "5rem"
+  - name: spacer-600
+    value: "6rem"
+  - name: spacer-700
+    value: "7rem"
+# Spacers -1 to -12 to be deprecated.
+# Retained for backwards compatibility.
   - name: spacer-1
-    value: "0.25rem" 
+    value: "0.25rem"
   - name: spacer-2
-    value: "0.5rem" 
+    value: "0.5rem"
   - name: spacer-3
     value: "0.75rem"
   - name: spacer-4


### PR DESCRIPTION
there's no namespace collision with the new token names, so they can be added alongside the originals to provide backwards compatibility until the old ones can be deprecated

DS-326, DS-327