### PR TITLE
feat(meganav): close dropdown when tabbing out of it

### DIFF
--- a/src/components/mega-nav/components/MegaNavDropdown.vue
+++ b/src/components/mega-nav/components/MegaNavDropdown.vue
@@ -36,6 +36,7 @@
                                 size="sm"
                                 variant="transparent"
                                 @click="closeMenu"
+                                @keydown.tab="closeMenu"
                             >
                                 <span class="visually-hidden">
                                     {{ menuToggleAltText }}

--- a/src/components/site-search/components/SiteSearchForm.vue
+++ b/src/components/site-search/components/SiteSearchForm.vue
@@ -61,6 +61,7 @@
             size="md"
             icon-only
             @click="closeSearchForm"
+            @keydown.tab="closeSearchForm"
         >
             <span class="visually-hidden">
                 {{ closeButtonText }}


### PR DESCRIPTION
Currently you can tab past the end of a meganav dropdown, continue along the main menu and then tab behind the open meganav producing some confusing results. The two options were either forcing the user to loop around inside the dropdown until you actually hit the close button, or auto closing it when you tab past the end of the nav (and off the close button, as the last item in it). The former option seems more confusing, especially for visually impaired users as it isn't clear why you're being looped around inside this box making no progress. The latter seems visually clear for people who can see the screen (as the nav closes and focus moves to the next meganav title) and intuitive for people who cannot, as they simply continue to progress through the navigation