### PR TITLE
Reduce Chromatic frequency

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -12,6 +12,8 @@ on:
     branches:
       - 'main'
       - 'cl-release/**'
+    schedule:
+      - cron: '0 8 * * 1'
 
   # Allows you to run this workflow manually from the Actions tab in the GitHub dashboard
   workflow_dispatch: {}

--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -9,7 +9,6 @@ on:
     types:
       - opened
       - reopened
-      - synchronize
     branches:
       - 'main'
       - 'cl-release/**'

--- a/src/components/button/Button.vue
+++ b/src/components/button/Button.vue
@@ -260,7 +260,7 @@ export default {
         ------------------------------------------ */
         &.btn-primary {
             @include vs-button-variant(
-                $vs-color-text-inverse, $vs-color-background-accent-glencoe, $vs-color-border-primary,
+                $vs-color-text-inverse, $vs-color-background-primary, $vs-color-border-primary,
                 $vs-color-text-inverse, $vs-color-background-hover, $vs-color-background-hover,
                 $vs-color-text-primary, $vs-color-background-active, $vs-color-background-active,
                 $vs-color-text-primary, $vs-color-background-inverse, $vs-color-border-primary,

--- a/src/components/button/Button.vue
+++ b/src/components/button/Button.vue
@@ -260,7 +260,7 @@ export default {
         ------------------------------------------ */
         &.btn-primary {
             @include vs-button-variant(
-                $vs-color-text-inverse, $vs-color-background-primary, $vs-color-border-primary,
+                $vs-color-text-inverse, $vs-color-background-accent-glencoe, $vs-color-border-primary,
                 $vs-color-text-inverse, $vs-color-background-hover, $vs-color-background-hover,
                 $vs-color-text-primary, $vs-color-background-active, $vs-color-background-active,
                 $vs-color-text-primary, $vs-color-background-inverse, $vs-color-border-primary,


### PR DESCRIPTION
Apols for the wall of text, tl;dr I think this change does all the things we planned for it to do when we caught up about it in the last UI dev chat

---

This change does seem to work as we wanted, it requires a little more manual attention than before but it should save some snapshots. When you first create a PR it runs the Chromatic action as desired (so in this case there were no changes and it passed). Pushing a change to the PR that creates a regression doesn't automatically run Chromatic so there is a mild risk that we can merge those commits, but we should be able to generally tell when you're pushing something that does or doesn't change the output, and whether or not there are going to be more changes before it's worth checking. If you then go into Actions and manually run Chromatic on your branch it will then attach that action to the PR as if it was automatically run, so if you have in fact introduced unaccepted changes it will then show that failure on the PR as it did before.

![image](https://github.com/user-attachments/assets/c22cd6e4-d406-4c25-9ddd-b5716f33a369)

Accepting those, or pushing another change to the PR then clears that out and renders it mergeable again, pending another manual call of Chromatic if it's needed.

This also adds a scheduled call which will run the action on the default branch (main) at 8am UTC every Monday. The visibility on that will be lower as it won't be in a PR, and in the good case it should not detect any changes as they will all be found within PRs, but if it does find anything it will display as a fail within the Actions tab as well as (I believe) sending out an email reporting it's build completion.

The worst case in usage terms here is that we run Chromatic manually every single time we push a change to a PR, but that worst case is the same as the pre-existing behaviour where it happens automatically, and the best case is that multiple changes can be pushed one at a time for testing then the action can be run once, once the testing has passed or you're confident you've done everything.

It is worth noting the risk that a developer could forget to run a test after introducing a change, but we can handle that through just habit building, and mentioning it in code reviews if a test doesn't appear to have been run on a change that might warrant it. We can also catch some of those failures by checking the weekly Chromatic job to make sure nothing has slipped through.