### PR TITLE
Ds 535 update global bootstrap heading styles and remove old tokens

### DIFF
--- a/src/components/heading/Heading.vue
+++ b/src/components/heading/Heading.vue
@@ -98,15 +98,11 @@ export default {
 
 <style lang="scss">
 [class*="vs-heading--display-"] {
-    font-family: $headings-font-family;
+    font-family: $display-font-family;
 
     .vs-heading__sub-heading {
         font-weight: $font-weight-semi-bold;
     }
-}
-
-[class*="vs-heading--heading-"] {
-    font-family: $font-family-sans-serif;
 }
 
 .vs-heading {

--- a/src/components/itineraries/components/ItineraryStop.vue
+++ b/src/components/itineraries/components/ItineraryStop.vue
@@ -147,7 +147,7 @@ export default {
     }
     .map-marker__count {
         color: $vs-color-text-inverse;
-        font-family: $headings-font-family;
+        font-family: $display-font-family;
         font-size: $font-size-4;
         display: block;
         position: absolute;

--- a/src/components/listicle/ListicleItem.vue
+++ b/src/components/listicle/ListicleItem.vue
@@ -119,7 +119,7 @@ export default {
 
     .count {
         color: $vs-color-text-inverse;
-        font-family: $headings-font-family;
+        font-family: $display-font-family;
         font-size: $font-size-8;
         line-height: $line-height-xs;
         display: block;

--- a/src/components/map-marker-icon/MapMarkerIcon.vue
+++ b/src/components/map-marker-icon/MapMarkerIcon.vue
@@ -111,7 +111,7 @@ export default {
         color: $vs-color-text-inverse;
         display: block;
         font-size: $font-size-4;
-        font-family: $headings-font-family;
+        font-family: $display-font-family;
         position: absolute;
         top: 4px;
         left: 0;

--- a/src/components/map-with-sidebar/components/MapWithSidebarListItem.vue
+++ b/src/components/map-with-sidebar/components/MapWithSidebarListItem.vue
@@ -181,7 +181,7 @@ export default {
         outline: none;
         background: none;
         border: none;
-        font-size: $font-size-h4;
+        font-size: $font-size-4;
         text-transform: none;
         font-family: $font-family-base;
         font-weight: $font-weight-bold;

--- a/src/components/product-search/ProductSearch.vue
+++ b/src/components/product-search/ProductSearch.vue
@@ -109,7 +109,6 @@ export default {
         width: 100%;
         background: $vs-color-background-accent-heather;
         padding: $spacer-200 $spacer-025;
-        font-family: $font-family-sans-serif;
 
         &__no-js {
             display: none;
@@ -128,7 +127,6 @@ export default {
 
         &__col--left {
             background: $vs-color-background-accent-heather;
-            font-family: $font-family-sans-serif;
             margin-bottom: $spacer-300;
         }
 

--- a/src/components/rich-text-wrapper/RichTextWrapper.vue
+++ b/src/components/rich-text-wrapper/RichTextWrapper.vue
@@ -38,7 +38,6 @@ export default {
 <style lang="scss">
 .vs-rich-text-wrapper {
     &--normal{
-        font-family: $font-family-base;
         font-size: $font-size-body;
 
         @include media-breakpoint-up(md) {

--- a/src/components/stretched-link-card/StretchedLinkCard.vue
+++ b/src/components/stretched-link-card/StretchedLinkCard.vue
@@ -482,7 +482,6 @@ export default {
         }
 
         .vs-stretched-link-card__category {
-            font-family: $font-family-base;
             font-size: $font-size-3;
             line-height: $line-height-xs;
             color: $vs-color-text-subtle;

--- a/src/components/summary-box/components/SummaryBoxDistanceListItem.vue
+++ b/src/components/summary-box/components/SummaryBoxDistanceListItem.vue
@@ -132,7 +132,7 @@ export default {
         width: 60%;
         text-align: left;
         vertical-align: middle;
-        font-family: $headings-font-family;
+        font-family: $display-font-family;
         font-weight: $font-weight-bold;
     }
 

--- a/src/components/summary-box/components/SummaryBoxListItem.vue
+++ b/src/components/summary-box/components/SummaryBoxListItem.vue
@@ -129,13 +129,9 @@ export default {
 }
 
 .vs-summary-box-item__display {
-    font-family: $headings-font-family;
+    font-family: $display-font-family;
     font-size: $font-size-9;
     bottom: 35%;
-
-    .divider {
-        font-family: $headings-font-family-thin;
-    }
 
     @include media-breakpoint-up(lg) {
         font-size: $font-size-10;

--- a/src/styles/_os-branding.scss
+++ b/src/styles/_os-branding.scss
@@ -28,7 +28,7 @@
     right: 0;
     padding: 0 4px;
     font-size: 10px;
-    font-family: $font_family_sans_serif;
+    font-family: $font-family-base;
     line-height: 16px;
     background: rgba(255, 255, 255, 0.7);
 }

--- a/src/styles/_placeholders.scss
+++ b/src/styles/_placeholders.scss
@@ -25,7 +25,6 @@ BUTTON STYLES
 ***************/
 
 %button-default-styles {
-    font-family: $font-family-base;
     font-weight: $font-weight-semi-bold;
     transition: $transition-base;
     text-decoration: none;
@@ -79,7 +78,6 @@ HEADING STYLES
 
 %sub-heading-default {
     display: block;
-    font-family: $font-family-sans-serif;
     font-weight: $font-weight-normal;
     line-height: $line-height-sub-heading;
     letter-spacing: $tracking-sub-heading;

--- a/src/styles/third-party/_cludo-search-results.scss
+++ b/src/styles/third-party/_cludo-search-results.scss
@@ -195,14 +195,9 @@
                         }
 
                         h2{
-                            font-size: $font-size-h2;
-                            letter-spacing: .15rem;
+                            @include heading-style(heading-m);
                             margin-top: 0;
                             margin-bottom: $spacer-075;
-
-                            @include media-breakpoint-up(md) {
-                                font-size: $font-size-h2-md;
-                            }
 
                             @include media-breakpoint-up(xl) {
                                 margin-top: $spacer-100;

--- a/src/tokens/font.yml
+++ b/src/tokens/font.yml
@@ -3,20 +3,14 @@
 # Use these tokens to set font-weight and font-family.
 #
 
-aliases:
-  font_family_default:
-    value: "'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'"
-  font_family_heading:
-    value: "'evelethclean-regular', sans-serif, $font-family-sans-serif"
-  font_family_heading_thin:
-    value: "'evelethclean-thin', 'evelethclean-thin', sans-serif, $font-family-sans-serif"
 props:
-  font_family_sans_serif:
-    value: "{!font_family_default}"
-  headings_font_family:
-    value: "{!font_family_heading}"
-  headings_font_family_thin:
-    value: "{!font_family_heading_thin}"
+  # This token sets the $font-family-base token in Bootstrap
+  # Use $font-family-base when setting the font-family in SCSS if needed
+  font-family-sans-serif:
+    value: "'Source Sans Pro', -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif, 'Apple Color Emoji', 'Segoe UI Emoji', 'Segoe UI Symbol'"
+  # Use only for display headings
+  display-font-family:
+    value: "'evelethclean-regular', sans-serif, $font-family-sans-serif"
 global:
   type: ...
   category: font

--- a/src/tokens/heading-size.yml
+++ b/src/tokens/heading-size.yml
@@ -2,6 +2,8 @@
 # HEADING-SIZE TOKENS
 # Use these tokens to set a heading-size.
 #
+
+props:
     - name: display-l
       value: "{!font-size-1000}"
     - name: display-m

--- a/src/tokens/heading-size.yml
+++ b/src/tokens/heading-size.yml
@@ -2,37 +2,6 @@
 # HEADING-SIZE TOKENS
 # Use these tokens to set a heading-size.
 #
-
-# To be deprecated
-props:
-    - name: font-size-h1
-      value: "1.5rem"
-    - name: font-size-h1-md
-      value: "1.875rem"
-    - name: font-size-h2
-      value: "1.25rem"
-    - name: font-size-h2-md
-      value: "1.5rem"
-    - name: font-size-h3
-      value: "1.125rem"
-    - name: font-size-h3-md
-      value: "1.25rem"
-    - name: font-size-h4
-      value: "1rem"
-    - name: font-size-h5
-      value: "1.25rem"
-    - name: font-size-h5-md
-      value: "1.375rem"
-    - name: font-size-h6
-      value: "1.125rem"
-    - name: font-size-h6-md
-      value: "1.25rem"
-    - name: font-size-h3-sub
-      value: "1rem"
-    - name: font-size-h2-sub
-      value: "1.25rem"
-
-# New heading sizes to replace old ones above
     - name: display-l
       value: "{!font-size-1000}"
     - name: display-m


### PR DESCRIPTION
I've removed the old heading-size tokens and updated the font-family tokens to use the bootstrap font-family-base where appropriate. I didn't understand at first how that worked so have left some comments on the font-family token file. 

Have also removed places the font-family was being set but it was already inheriting the default font-family. 