### PR TITLE
feat(skip to): add ability to remove search from skip to

### DIFF
--- a/src/components/skip-to/SkipTo.vue
+++ b/src/components/skip-to/SkipTo.vue
@@ -23,6 +23,7 @@
             href="#site-search-btn"
             data-test="vs-skip-to-search"
             class="vs-skip-to__search"
+            v-if="hasSearchLink"
         >
             <!-- @slot text for 'Search' -->
             <slot name="search-text" />
@@ -69,6 +70,13 @@ export default {
         skipToText: {
             type: String,
             required: true,
+        },
+        /**
+         * Controls whether a link to a search component appears in the skip to
+         */
+        hasSearchLink: {
+            type: Boolean,
+            default: true,
         },
     },
     methods: {

--- a/src/components/skip-to/__tests__/SkipTo.jest.spec.js
+++ b/src/components/skip-to/__tests__/SkipTo.jest.spec.js
@@ -50,6 +50,20 @@ describe('VsSiteSearch', () => {
             expect(wrapper.attributes('aria-label')).toBe('Skip to');
             expect(wrapper.find('[data-test="vs-skip-to"]').find('.vs-skip-to__label').text()).toContain('Skip to');
         });
+
+        it('should render the `search` link if `hasSearchLink` === true', () => {
+            expect(wrapper.find('[data-test="vs-skip-to-search"]').exists()).toBe(true);
+        });
+
+        it('should skip the `search` link if `hasSearchLink` === false', async() => {
+            wrapper.setProps({
+                hasSearchLink: false,
+            });
+
+            await wrapper.vm.$nextTick();
+
+            expect(wrapper.find('[data-test="vs-skip-to-search"]').exists()).toBe(false);
+        });
     });
     describe(':slots', () => {
         it('should render the content of the `mainMenuText` slot', () => {

--- a/stories/SkipTo.stories.js
+++ b/stories/SkipTo.stories.js
@@ -47,6 +47,7 @@ const Template = (args) => ({
         <div class="border" style="overflow: hidden; position: relative;">
             <VsSkipTo
                 skip-to-text="${args.skipToText}"
+                v-bind="args"
             >   
                 <template v-slot:main-menu-text>
                     ${args.mainMenuText}
@@ -77,3 +78,11 @@ export const Default = Template.bind({
 });
 
 Default.args = base;
+
+export const NoSearch = Template.bind({
+});
+
+NoSearch.args = {
+    ...base,
+    hasSearchLink: false,
+};


### PR DESCRIPTION
We need to add Skip To to Business Events and the Business Support Hub, BE doesn't have a search, BSH I'm not sure about but this just makes that link optional