### PR TITLE
feat(engagement): adjust exponea.identify syntax to fire event immediately

### DIFF
--- a/src/components/form/Form.vue
+++ b/src/components/form/Form.vue
@@ -763,9 +763,15 @@ export default {
 
             if (this.emailFieldName && typeof exponea !== 'undefined') {
                 // eslint-disable-next-line no-undef
-                exponea.identify({
-                    email_id: this.form[this.emailFieldName],
-                });
+                exponea.identify(
+                    {
+                        email_id: this.form[this.emailFieldName],
+                    },
+                    null,
+                    null,
+                    null,
+                    true,
+                );
             }
         },
         /**


### PR DESCRIPTION
This wasn't working consistently. This turns on an option to fire the identify event instantly, rather than waiting for the next bundled event which was sometimes not happening before the user left the site.