### PR TITLE
Ds 282 play button displaying video duration incorrectly after closing the modal

### DIFF
--- a/src/components/modal/Modal.vue
+++ b/src/components/modal/Modal.vue
@@ -10,6 +10,7 @@
         :static="isVideoModal"
         v-model="show"
         v-if="mounted"
+        @hidden="hideModal"
     >
         <VsContainer>
             <VsRow>

--- a/src/components/video/Video.vue
+++ b/src/components/video/Video.vue
@@ -183,6 +183,14 @@ export default {
             }
         },
         /**
+         * Stops the video, which resets to beginning
+         */
+        async stopVideo(){
+            if (this.player) {
+                await this.player.stopVideo();
+            }
+        },
+        /**
          * Triggered by video status events from the vue-youtube component. When any of these
          * occur an appropriate analytics event is dispatched to the datalayer.
          */
@@ -309,7 +317,7 @@ export default {
                             this.playVideo();
                         }
                         if(args.action === 'modal-closed'){
-                            this.pauseVideo();
+                            this.stopVideo();
                         }
 
                         if (args.action === 'play') {

--- a/src/components/video/Video.vue
+++ b/src/components/video/Video.vue
@@ -244,12 +244,14 @@ export default {
          */
         formatTime(timeInSeconds) {
             const minutes = Math.floor(timeInSeconds / 60);
-            const seconds = timeInSeconds - (minutes * 60);
+            const seconds = Math.round(timeInSeconds - (minutes * 60));
 
             this.duration.minutes = minutes;
             this.duration.seconds = seconds;
 
             const roundedMinutes = this.getRoundedMinutes(minutes, seconds);
+
+            console.log(this.player.getDuration());
 
             this.duration.roundedMinutes = this.formatSingularOrPlural(roundedMinutes);
         },
@@ -310,7 +312,7 @@ export default {
                             this.playVideo();
                         }
                         if (args.action === 'modal-closed') {
-                            this.reRenderVideo();
+                            //this.reRenderVideo();
                         }
 
                         if (args.action === 'play') {

--- a/src/components/video/Video.vue
+++ b/src/components/video/Video.vue
@@ -299,8 +299,7 @@ export default {
         },
         /**
          * Attaches event listeners upon mounting video. These include play and pause functions,
-         * for external play buttons and re-render + autoplay functionality for a video inside
-         * a modal.
+         * for external play buttons and autoplay functionality for a video inside a modal.
          */
         setEventListeners() {
             if (this.emitter) {
@@ -308,6 +307,9 @@ export default {
                     if (args.id === this.videoId) {
                         if (args.action === 'modal-opened') {
                             this.playVideo();
+                        }
+                        if(args.action === 'modal-closed'){
+                            this.pauseVideo();
                         }
 
                         if (args.action === 'play') {

--- a/src/components/video/Video.vue
+++ b/src/components/video/Video.vue
@@ -251,8 +251,6 @@ export default {
 
             const roundedMinutes = this.getRoundedMinutes(minutes, seconds);
 
-            console.log(this.player.getDuration());
-
             this.duration.roundedMinutes = this.formatSingularOrPlural(roundedMinutes);
         },
         /**
@@ -311,9 +309,6 @@ export default {
                         if (args.action === 'modal-opened') {
                             this.playVideo();
                         }
-                        if (args.action === 'modal-closed') {
-                            //this.reRenderVideo();
-                        }
 
                         if (args.action === 'play') {
                             this.playVideo();
@@ -323,19 +318,6 @@ export default {
                     }
                 });
             }
-        },
-        /**
-         * Upon opening a vs-modal with a video, the video must be briefly removed and re-rendered
-         * to ensure that all event triggers in the video fire properly.
-         */
-        reRenderVideo() {
-            this.reRendering = true;
-            this.$nextTick(() => {
-                this.reRendering = false;
-                this.$nextTick(() => {
-                    this.shouldAutoPlay = true;
-                });
-            });
         },
     },
 };


### PR DESCRIPTION
Fixed the duration changing incorrectly when modal closed.

Caused by a re-render of the video player when the modal closed, removed this re-render and added a round function to the seconds count to ensure it doesn't display decimal places as seconds are passed in as full numbers.