### PR TITLE
fix(socialshare): social share popover is now fully on screen when mobile layouts

### DIFF
--- a/src/components/social-share/SocialShare.vue
+++ b/src/components/social-share/SocialShare.vue
@@ -22,6 +22,7 @@
             :click="true"
             container="body"
             placement="left-end"
+            offset="-100"
             @shown="onShown"
             @hidden="onHidden"
             @hide="onHide"


### PR DESCRIPTION
Just added an offset to the bootstrap popover component so that the share popover moves over on the screen, making it fully visible on mobile.