### PR TITLE
DS-665 - Add logic to prevent Boolean values within JSON being sent as strings

### DIFF
--- a/src/components/form/Form.vue
+++ b/src/components/form/Form.vue
@@ -565,16 +565,47 @@ export default {
 
             return '';
         },
+        /**
+         * Collects all hidden input fields within the current element, parses their values, and
+         * returns an array of parsed objects.
+         * The values of the hidden inputs are checked for 'true' or 'false' strings and converted
+         * to boolean values accordingly.
+         *
+         * @returns {Array<{name: string, value: boolean|string}>} - An array of objects, each
+         * containing:
+         *   - `name`: The name of the hidden input field.
+         *   - `value`: The parsed value of the input field, where 'true' becomes `true`,
+         *     'false' becomes `false`, and other values remain as strings.
+         */
         getHiddenFields() {
             const hiddenInputFields = this.$el.querySelectorAll('input[type=hidden]');
-            const fieldData = {
+
+            return [...hiddenInputFields].map(this.parseBooleanStringsFromInputField);
+        },
+        /**
+         * Parses the value of an input field, converting 'true' and 'false' string values to their
+         * boolean primitive equivalents.
+         *
+         * @param {HTMLInputElement} inputField - The input field element to process. It must have a
+         * `value` and `name` property.
+         * @returns {{name: string, value: boolean|string}} - An object containing:
+         *   - `name`: The name of the input field.
+         *   - `value`: The parsed value of the input field. Returns `true` if the value is 'true',
+         *     `false` if the value is 'false', and the original value otherwise.
+         */
+        parseBooleanStringsFromInputField(inputField) {
+            let value = inputField.value;
+
+            if (value === 'true') {
+                value = true;
+            } else if (value === 'false') {
+                value = false;
+            }
+
+            return {
+                name: inputField.name,
+                value,
             };
-
-            hiddenInputFields.forEach((field) => {
-                fieldData[field.name] = field.value;
-            });
-
-            return fieldData;
         },
         /**
          * Returns true if a given value is undefined

--- a/src/components/form/__tests__/Form.jest.spec.js
+++ b/src/components/form/__tests__/Form.jest.spec.js
@@ -381,6 +381,51 @@ describe('VsForm', () => {
 
             expect(wrapper.vm.emailFieldName).toBe('Email');
         });
+
+        it('should return an object with the name and a boolean true value for "true"', () => {
+            const wrapper = factoryMount();
+            const inputField = {
+                name: 'testField',
+                value: 'true',
+            };
+
+            const result = wrapper.vm.parseBooleanStringsFromInputField(inputField);
+
+            expect(result).toEqual({
+                name: 'testField',
+                value: true,
+            });
+        });
+
+        it('should return an object with the name and a boolean false value for "false"', () => {
+            const wrapper = factoryMount();
+            const inputField = {
+                name: 'testField',
+                value: 'false',
+            };
+
+            const result = wrapper.vm.parseBooleanStringsFromInputField(inputField);
+
+            expect(result).toEqual({
+                name: 'testField',
+                value: false,
+            });
+        });
+
+        it('should return an object with the name and the original string value for other inputs', () => {
+            const wrapper = factoryMount();
+            const inputField = {
+                name: 'testField',
+                value: 'someString',
+            };
+
+            const result = wrapper.vm.parseBooleanStringsFromInputField(inputField);
+
+            expect(result).toEqual({
+                name: 'testField',
+                value: 'someString',
+            });
+        });
     });
 
     describe(':accessibility', () => {


### PR DESCRIPTION
fix(form.vue): add logic in Form.vue to parse hidden inputs and convert 'true/false' to booleans

Enhanced Form.vue by introducing a method to process hidden input fields, extracting their name and value attributes. Implemented a utility function to parse value strings, converting 'true' and 'false' into boolean primitives while retaining other string values. The getHiddenFields method collects all hidden inputs within the component, applies this parsing logic, and returns an array of objects representing each field with its parsed value. This update ensures proper handling of boolean values from hidden fields, improving data accuracy and reliability