### PR TITLE
style(page intro): restore double colourway highlight for video caption

### DIFF
--- a/src/components/button/Button.vue
+++ b/src/components/button/Button.vue
@@ -256,8 +256,10 @@ export default {
                 );
             }
 
-            &:focus {
-                box-shadow: 0 0 0 2px $vs-color-interaction-focus;
+            &:not(.vs-video-caption__toggle-button) {
+                &:focus {
+                    box-shadow: 0 0 0 2px $vs-color-interaction-focus;
+                }
             }
         }
 

--- a/src/components/button/Button.vue
+++ b/src/components/button/Button.vue
@@ -255,12 +255,6 @@ export default {
                     $vs-color-text-inverse, $vs-color-interaction-cta-subtle-pressed, $vs-color-interaction-cta-subtle-pressed,
                 );
             }
-
-            &:not(.vs-video-caption__toggle-button) {
-                &:focus {
-                    box-shadow: 0 0 0 2px $vs-color-interaction-focus;
-                }
-            }
         }
 
         &.vs-button--icon-only {

--- a/src/components/video-caption/VideoCaption.vue
+++ b/src/components/video-caption/VideoCaption.vue
@@ -31,7 +31,6 @@
 
                 <VsToggleButton
                     v-if="withToggleBtn"
-                    class="vs-video-caption__toggle-button"
                     @toggle-action="emitToggle"
                 >
                     <span class="visually-hidden">

--- a/src/components/video-caption/VideoCaption.vue
+++ b/src/components/video-caption/VideoCaption.vue
@@ -31,6 +31,7 @@
 
                 <VsToggleButton
                     v-if="withToggleBtn"
+                    class="vs-video-caption__toggle-button"
                     @toggle-action="emitToggle"
                 >
                     <span class="visually-hidden">


### PR DESCRIPTION
We need the standard double highlight focus state (a white and then a blue shadow) to fix an accessibility issue on business events, with a very dark image obscuring the blue shadow. Ideally we'd make this a universal change, but I checked with Craig and his preference was to change it for just the video caption for now, and to then review other potential instances of this issue within the Design System project. If it can be universalised the rule can just be removed entirely.