### PR TITLE
ci(chromatic): return to firing chromatic every time we push to a PR

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -9,11 +9,10 @@ on:
     types:
       - opened
       - reopened
+      - synchronize
     branches:
       - 'main'
       - 'cl-release/**'
-    schedule:
-      - cron: '0 8 * * 1'
 
   # Allows you to run this workflow manually from the Actions tab in the GitHub dashboard
   workflow_dispatch: {}


### PR DESCRIPTION
Now we have a ton of extra Snapshots every month as an OS public sector project we probably don't need this restriction any more, we're a way off the limit at the moment and losing the chromatic link if you push or pull in main is annoying. Moving forward we can keep an eye and see if we need to restore this