### PR TITLE
fix(icons): some icon names have changed

### DIFF
--- a/src/components/icon/Icon.vue
+++ b/src/components/icon/Icon.vue
@@ -220,10 +220,6 @@ export default {
                     value: 'level-entry-shower',
                 },
                 {
-                    key: 'x-twitter',
-                    value: 'x-twitter fa-brands',
-                },
-                {
                     key: 'linkedin',
                     value: 'linkedin-in fa-brands',
                 },

--- a/src/components/warning/Warning.vue
+++ b/src/components/warning/Warning.vue
@@ -59,7 +59,7 @@ export default {
         */
         icon: {
             type: String,
-            default: 'review',
+            default: 'warning',
         },
         /**
         * Type of warning


### PR DESCRIPTION
The `review` icon is now called `warning` and we're now using our custom `x-twitter` icon instead of the brand version.