### PR TITLE
fix(stretchedlinkcard.vue): remove BSH-specific prop resolution

### DIFF
--- a/src/components/stretched-link-card/StretchedLinkCard.vue
+++ b/src/components/stretched-link-card/StretchedLinkCard.vue
@@ -122,7 +122,7 @@
                 <VsLink
                     v-else
                     :href="link"
-                    :type="(businessSupport && isHomePage) ? 'default' : type"
+                    :type="type"
                     class="stretched-link"
                     :class="disabled ? 'stretched-link--disabled' : ''"
                     :variant="theme === 'dark' ? 'on-dark' : 'primary'"


### PR DESCRIPTION
This condition was added in response to an erroneous design