### PR TITLE
fix(bootstrap): suppress deprecation warnings

### DIFF
--- a/vite.config.mts
+++ b/vite.config.mts
@@ -18,6 +18,7 @@ export default defineConfig(({ mode }) => {
                     additionalData: `
                         @import "@/styles/resources.scss";
                     `,
+                    silenceDeprecations: ['mixed-decls', 'color-functions', 'global-builtin', 'import', 'legacy-js-api'],
                 },
             },
         },


### PR DESCRIPTION
These deprecation warnings are a known issue with recent versions of bootstrap and node. Long term it looks like it'll take a significant rewrite within bootstrap to ditch some dependencies, for now the recommended solution is just to suppress them pending those fixes, as they're just distracting

https://github.com/twbs/bootstrap/issues/40962 