### PR TITLE
Bshub 465 fed enquiries display error message to user

### DIFF
--- a/src/components/form/Form.vue
+++ b/src/components/form/Form.vue
@@ -685,6 +685,7 @@ export default {
          */
         preSubmit(e) {
             e.preventDefault();
+            this.submitError = false;
 
             function isRequired(value) {
                 return value.validation && value.validation.required;
@@ -741,6 +742,7 @@ export default {
             } else {
                 this.showErrorMessage = true;
                 this.reAlertErrors = true;
+                this.submitError = true;
 
                 setTimeout(() => {
                     this.reAlertErrors = false;

--- a/src/components/form/Form.vue
+++ b/src/components/form/Form.vue
@@ -161,7 +161,10 @@
                 />
             </template>
 
-            <p v-if="submitError">
+            <p
+                v-if="submitError"
+                class="mt-200"
+            >
                 <slot name="submit-error" />
             </p>
         </div>
@@ -742,7 +745,6 @@ export default {
             } else {
                 this.showErrorMessage = true;
                 this.reAlertErrors = true;
-                this.submitError = true;
 
                 setTimeout(() => {
                     this.reAlertErrors = false;
@@ -805,7 +807,10 @@ export default {
                 this.submitted = true;
                 this.attachEmail();
                 return false;
-            }).catch(() => {});
+            }).catch(() => {
+                this.submitError = true;
+                return false;
+            });
         },
         /**
          * If exponea is present in the window (via gtm with accepted cookies), attach the

--- a/stories/Form.stories.js
+++ b/stories/Form.stories.js
@@ -40,6 +40,10 @@ const Template = (args) => ({
                 <template v-slot:no-js v-if="args['no-js']">
                     <p>{{ args['no-js'] }}</p>
                 </template>
+
+                <template v-slot:submit-error v-if="args['submit-error']">
+                    {{ args['submit-error'] }}
+                </template>
             </VsForm>
         </div>
     `,


### PR DESCRIPTION
As there's currently a processing error in the BREG layer for some sectors on BSH we've been asked to display an error for the form as a whole if something goes wrong on submission. Looking at it this system, it seems that we've always had a slot for this value and everything in place to render it but we've never set the boolean to true. The label for it also exists in the .com cms and is being passed into the form in ftl. That goes back to at least before we moved from the .com repo into the separate component library one. Does anyone know why? Is it just an incomplete feature or did we drop it for some reason?

In practice it's only going to appear if all the fields are correct and filled out but an error comes from the back end, which is rare outside of this particular circumstance.

![image](https://github.com/user-attachments/assets/65e90cbb-e1a9-4a69-bf94-f7ca182db199)
