### PR TITLE
fix(megalinks): stop accessing scaler for SVGs and fix layout in stretched link cards

### DIFF
--- a/src/components/img/Img.vue
+++ b/src/components/img/Img.vue
@@ -106,7 +106,7 @@ export default {
     },
     computed: {
         imgStyle() {
-            if (!this.useGenericLqip) {
+            if (!this.useGenericLqip && !this.src.includes('.svg')) {
                 return {
                     backgroundImage: `url(${this.specificImgSize('xxs')})`,
                 };

--- a/src/components/img/Img.vue
+++ b/src/components/img/Img.vue
@@ -9,8 +9,8 @@
         :style="imgStyle"
         class="low-res-img"
         :class="useGenericLqip ? 'generic-lqip' : ''"
-        :srcset="$attrs.srcset ? $attrs.srcset : fullSrcSet"
-        :low-res-image="specificImgSize('xxs')"
+        :srcset="computedSrcSet"
+        :low-res-image="isSvg ? '' : specificImgSize('xxs')"
         sizes="(min-width: 768px) 75vw, 100vw"
     >
         <VsIcon
@@ -113,6 +113,20 @@ export default {
             }
 
             return null;
+        },
+        isSvg() {
+            return this.src.includes('.svg');
+        },
+        computedSrcSet() {
+            if (this.isSvg) {
+                return null;
+            }
+
+            if (this.$attrs.srcset) {
+                return this.$attrs.srcset;
+            }
+
+            return this.fullSrcSet;
         },
     },
 };

--- a/src/components/stretched-link-card/StretchedLinkCard.vue
+++ b/src/components/stretched-link-card/StretchedLinkCard.vue
@@ -35,6 +35,7 @@
                     :src="imgSrc"
                     :alt="imgAlt"
                     class="vs-stretched-link-card__img"
+                    :class="isSvg ? 'vs-stretched-link-card__img--svg' : ''"
                     data-test="vs-stretched-link-card__img"
                     data-chromatic="ignore"
                 />
@@ -398,6 +399,13 @@ export default {
 
             return attrsObj;
         },
+        isSvg() {
+            if (this.imgSrc && this.imgSrc.includes('.svg')) {
+                return true;
+            }
+
+            return false;
+        },
     },
     mounted() {
         // Checks whether js is disabled, to display an appropriate warning to the user
@@ -467,6 +475,10 @@ export default {
                 object-fit: cover;
                 align-self: flex-start;
                 flex-shrink: 0; // IE11 fix, prevents image vertical stretching
+
+                &--svg {
+                    object-fit: contain;
+                }
             }
         }
 

--- a/stories/MegalinksLinkList.stories.js
+++ b/stories/MegalinksLinkList.stories.js
@@ -292,7 +292,7 @@ const businessSupportBase = {
     isHomePage: false,
     links: [
         {
-            imgSrc: './fixtures/megalinks/glentress-forest.jpg',
+            imgSrc: './fixtures/image-with-caption/images/thistle.svg',
             imgAlt: 'Clycling in glentress forest',
             linkType: 'internal',
             linkUrl: '#',


### PR DESCRIPTION
The scaler doesn't do anything with SVGs, creating some weird outcomes in stretched link cards

![image](https://github.com/user-attachments/assets/a1662d4e-25d3-4bb3-bf24-41ba28e367ec)

This prevents svg images from attempting to scale, and fixes the subsequent layout problems in those link lists

![image](https://github.com/user-attachments/assets/41e1eba6-c1ff-4092-8cb7-983b03d3a63a)
