### PR TITLE
feat(article): reduce spacing above vs-heading at top of article

### DIFF
--- a/src/components/article/Article.vue
+++ b/src/components/article/Article.vue
@@ -160,7 +160,7 @@ export default {
     &--no-intro {
         .vs-article-section:first-of-type {
             .vs-heading:first-child {
-                margin-top: 0;
+                margin-top: $spacer-0;
             }
         }
     }

--- a/src/components/article/Article.vue
+++ b/src/components/article/Article.vue
@@ -1,7 +1,6 @@
 <template>
     <article
         class="vs-article"
-        :class="!hasIntro ? 'vs-article--no-intro' : null"
         data-test="vs-article"
         v-bind="$attrs"
     >
@@ -43,7 +42,7 @@
                                     </VsHeading>
 
                                     <VsRichTextWrapper
-                                        v-if="hasIntro"
+                                        v-if="$slots['vs-article-intro']"
                                         variant="lead"
                                         class="mb-300 mb-lg-400"
                                         :class="businessSupport ? null : 'text-center'"
@@ -135,11 +134,6 @@ export default {
             validator: (value) => (isNumber(value) ? value > 0 && value < 7 : value.match(/(1|2|3|4|5|6)/)),
         },
     },
-    computed: {
-        hasIntro() {
-            return this.$slots['vs-article-intro'];
-        },
-    },
 };
 </script>
 
@@ -157,11 +151,9 @@ export default {
         }
     }
 
-    &--no-intro {
-        .vs-article-section:first-of-type {
-            .vs-heading:first-child {
-                margin-top: $spacer-0;
-            }
+    .vs-article-section:first-of-type {
+        .vs-heading:first-child {
+            margin-top: $spacer-0;
         }
     }
 

--- a/src/components/article/Article.vue
+++ b/src/components/article/Article.vue
@@ -1,6 +1,7 @@
 <template>
     <article
         class="vs-article"
+        :class="!hasIntro ? 'vs-article--no-intro' : null"
         data-test="vs-article"
         v-bind="$attrs"
     >
@@ -42,7 +43,7 @@
                                     </VsHeading>
 
                                     <VsRichTextWrapper
-                                        v-if="$slots['vs-article-intro']"
+                                        v-if="hasIntro"
                                         variant="lead"
                                         class="mb-300 mb-lg-400"
                                         :class="businessSupport ? null : 'text-center'"
@@ -134,6 +135,11 @@ export default {
             validator: (value) => (isNumber(value) ? value > 0 && value < 7 : value.match(/(1|2|3|4|5|6)/)),
         },
     },
+    computed: {
+        hasIntro() {
+            return this.$slots['vs-article-intro'];
+        },
+    },
 };
 </script>
 
@@ -148,6 +154,14 @@ export default {
 
         &--no-border {
             border: 0;
+        }
+    }
+
+    &--no-intro {
+        .vs-article-section:first-of-type {
+            .vs-heading:first-child {
+                margin-top: 0;
+            }
         }
     }
 

--- a/stories/Article.stories.js
+++ b/stories/Article.stories.js
@@ -169,7 +169,12 @@ const Template = (args) => ({
                         </VsArticleSidebar>
                     </template>
 
-                    ${args.defaultContent}
+                    <template v-if="args.hasSubheaders">
+                        ${args.hasHeadersContent}
+                    </template>
+                    <template v-else>
+                        ${args.defaultContent}
+                    </template
 
                 </VsArticleSection>
             </VsArticle>
@@ -217,6 +222,14 @@ const base = {
         <p>Ben Nevis is the king of them all. In the north west <a href='#'>Highlands</a>, near the town of <a href='#'>Fort William</a> and part of the <a href='#'>Grampian Mountain</a> range, the famous peak attracts 125k walkers a year. Whether you're an avid ambler or you just love beautiful landscapes, bagging 'the Ben' is likely to feature near the top of your Scottish bucket list.</p>
         <p>An ancient giant of the land, Ben Nevis was once a massive active volcano which exploded and collapsed inwards on itself millions of years ago. At the summit, there is evidence of an explosion in the form of light-coloured granite. The name itself has two translations from the ancient Gaelic language, meaning 'mountain with its head in the clouds', thanks to its iconic mist-shrouded peak, or it can also mean 'venomous mountain' - you can decide which translation you prefer after the climb!</p>
         <p>Read on for an overview of walking routes up the mountain, or visit <a href='#'>Walk Highlands</a> for detailed maps, difficulty levels and walking advice.</p>
+        <p>Remember it's never 'easy' to bag a Scottish Munro or Corbett. You'll need a good amount of hillwalking experience, fitness, hill craft and navigation skills using a map and compass, before attempting any Scottish mountains, even more so in winter.</p>
+    `,
+    hasHeadersContent: `
+        <vs-heading level="3">The mountain</vs-heading>
+        <p>Ben Nevis is the king of them all. In the north west <a href='#'>Highlands</a>, near the town of <a href='#'>Fort William</a> and part of the <a href='#'>Grampian Mountain</a> range, the famous peak attracts 125k walkers a year. Whether you're an avid ambler or you just love beautiful landscapes, bagging 'the Ben' is likely to feature near the top of your Scottish bucket list.</p>
+        <p>An ancient giant of the land, Ben Nevis was once a massive active volcano which exploded and collapsed inwards on itself millions of years ago. At the summit, there is evidence of an explosion in the form of light-coloured granite. The name itself has two translations from the ancient Gaelic language, meaning 'mountain with its head in the clouds', thanks to its iconic mist-shrouded peak, or it can also mean 'venomous mountain' - you can decide which translation you prefer after the climb!</p>
+        <p>Read on for an overview of walking routes up the mountain, or visit <a href='#'>Walk Highlands</a> for detailed maps, difficulty levels and walking advice.</p>
+        <vs-heading level="3">Experience</vs-heading>
         <p>Remember it's never 'easy' to bag a Scottish Munro or Corbett. You'll need a good amount of hillwalking experience, fitness, hill craft and navigation skills using a map and compass, before attempting any Scottish mountains, even more so in winter.</p>
     `,
     jsDisabled: false,
@@ -285,6 +298,15 @@ BusinessSupportHubNoSidebar.args = {
     ...BusinessSupportHub.args,
     sidebarImg: '',
     sidebarQuote: '',
+};
+
+export const BusinessSupportHubNoIntro = Template.bind();
+BusinessSupportHubNoIntro.args = {
+    ...base,
+    sidebarAlign: 'right',
+    businessSupport: true,
+    'vs-article-intro': null,
+    hasSubheaders: true,
 };
 
 export const NoCookies = Template.bind();

--- a/stories/Article.stories.js
+++ b/stories/Article.stories.js
@@ -300,8 +300,8 @@ BusinessSupportHubNoSidebar.args = {
     sidebarQuote: '',
 };
 
-export const BusinessSupportHubNoIntro = Template.bind();
-BusinessSupportHubNoIntro.args = {
+export const BusinessSupportHubWithSubheaders = Template.bind();
+BusinessSupportHubWithSubheaders.args = {
     ...base,
     sidebarAlign: 'right',
     businessSupport: true,


### PR DESCRIPTION
If the first item in the first section of an article is a vs-heading it creates additional spacing between it and the intro (or the H2 if there is no intro) which pads out the page. This should just remove that top margin in that specific case