### PR TITLE
BSHUB-536 Event listings tracking datalayer work

### DIFF
--- a/src/components/tabs/components/TabItem.vue
+++ b/src/components/tabs/components/TabItem.vue
@@ -4,6 +4,7 @@
         data-test="vs-tab__item"
         :title-link-class="noContainer ? 'vs-tab-link--no-container vs-heading' : 'vs-tab-link vs-heading'"
         :title="title"
+        @click="trackClick"
     >
         <VsHeading
             level="3"
@@ -22,6 +23,7 @@
 
 import VsHeading from '@/components/heading/Heading.vue';
 import { BTab } from 'bootstrap-vue-next';
+import dataLayerMixin from '@/mixins/dataLayerMixin';
 /**
  * Tab item for use within the Tabs component.
  *
@@ -35,6 +37,7 @@ export default {
         VsHeading,
         BTab,
     },
+    mixins: [dataLayerMixin],
     /**
      * Injects noContainer prop from Tab parent.
      */
@@ -46,6 +49,11 @@ export default {
         title: {
             type: String,
             required: true,
+        },
+    },
+    methods: {
+        trackClick(event) {
+            this.createDataLayerObject('tabClickEvent', event, null);
         },
     },
 };

--- a/src/mixins/dataLayerMixin.js
+++ b/src/mixins/dataLayerMixin.js
@@ -21,6 +21,7 @@ import {
     productSearchTemplate,
     cmsReferralTemplate,
     accordionOpenTemplate,
+    tabClickTemplate,
 } from '../utils/data-layer-templates';
 
 /**
@@ -91,12 +92,22 @@ const dataLayerMixin = {
             let dataLayerData;
             let clickText;
             let socialTargetText = '';
+            let eventListing = 'False';
 
             if (event && event.target) {
                 if (event.target.text) {
                     clickText = event.target.text.trim();
                 } else {
                     clickText = event.target.innerText;
+                }
+
+                // An additional property is required for tracking tab and eventCard
+                // components when used on an events listing page (e.g. on BSH).
+                // A data attribute needs to be added to the these components
+                // on the consumer site to indicate that it is being used on
+                // an events listing page.
+                if (event.target.closest('[data-event-listing="True"]')) {
+                    eventListing = 'True';
                 }
             }
 
@@ -183,6 +194,7 @@ const dataLayerMixin = {
                     click_text: clickText,
                     click_URL: href,
                     partner_referral: 'False',
+                    event_listing: eventListing,
                 };
 
                 for (let x = 0; x < signpostedPartners.length; x++) {
@@ -339,6 +351,22 @@ const dataLayerMixin = {
 
                 fullTemplate = this.compileFullTemplate(templateValues);
                 dataLayerData = this.templateFiller(accordionOpenTemplate, fullTemplate);
+
+                break;
+
+            case 'tabClickEvent':
+                eventName = 'tab_click';
+                tagName = 'GA4 - Event - Tab Click';
+
+                templateValues = {
+                    event: eventName,
+                    tag_name: tagName,
+                    event_tab: clickText,
+                    event_listing: eventListing,
+                };
+
+                fullTemplate = this.compileFullTemplate(templateValues);
+                dataLayerData = this.templateFiller(tabClickTemplate, fullTemplate);
 
                 break;
 

--- a/src/utils/data-layer-templates.js
+++ b/src/utils/data-layer-templates.js
@@ -174,6 +174,7 @@ const externalLinkTemplate = [
     'click_URL',
     'dmo_referral',
     'partner_referral',
+    'event_listing',
 ];
 
 const internalLinkTemplate = [
@@ -351,6 +352,17 @@ const accordionOpenTemplate = [
     'accordion_text',
 ];
 
+const tabClickTemplate = [
+    'event',
+    'event_tab',
+    'site_language',
+    'user_country_setting',
+    'hit_timestamp',
+    'tag_name',
+    'meta_data',
+    'event_listing',
+];
+
 export {
     pageViewTemplate,
     menuNavigationTemplate,
@@ -371,4 +383,5 @@ export {
     productSearchTemplate,
     cmsReferralTemplate,
     accordionOpenTemplate,
+    tabClickTemplate,
 };


### PR DESCRIPTION
Added a datalayer event for tab clicks.

There was a requirement to specifically track the tab and eventCard components on the BSH events listing page so I've added a property to the `tabClickTemplate` and `externalLinkTemplate` datalayer templates for this. This property is set to "True" when these components have the `data-event-listing="True"` attribute,  which needs to be added on the BSH site. Not an ideal solution but couldn't think of another way for these components to know that there were on the events listing page.