### PR TITLE
BSHUB-674 Horizontal scrollbar appears when screen width is 1400px

### DIFF
--- a/src/components/filter/components/VsFilterSection.vue
+++ b/src/components/filter/components/VsFilterSection.vue
@@ -102,9 +102,5 @@ const filterSectionClasses = computed(() => ({
             transform: scale(-1, -1);
         }
     }
-
-    input[type="date"] {
-        width: 125px;
-    }
 }
 </style>


### PR DESCRIPTION
Removing the set width on the date picker used within the filter component as it is too narrow on Firefox