### PR TITLE
feat(heading and megallinks): added `id` prop to VsHeading and `secti…

### DIFF
--- a/src/components/heading/Heading.vue
+++ b/src/components/heading/Heading.vue
@@ -3,6 +3,7 @@
         :is="type"
         class="vs-heading"
         :class="headingClasses"
+        :id="id"
     >
         <!-- @slot The main heading content goes here -->
         <slot />
@@ -51,6 +52,14 @@ export default {
             validator: (value) => value.match(
                 /(display-l|display-m|display-s|display-xs|heading-xxl|heading-xl|heading-l|heading-m|heading-s|heading-xs|heading-xxs|heading-xxxs)/,
             ),
+        },
+        /**
+         * id string for h tag
+         * typically — though not necessarily — used as page anchor
+         */
+        id: {
+            type: String,
+            default: null,
         },
     },
     computed: {

--- a/src/components/heading/__tests__/Heading.jest.spec.js
+++ b/src/components/heading/__tests__/Heading.jest.spec.js
@@ -32,6 +32,22 @@ describe('VsHeading', () => {
             expect(wrapper.element.tagName).toBe('H2');
         });
 
+        it(':id - should use contain an matching `id` attribute if the prop is provided', () => {
+            const wrapper = factoryShallowMount({
+                id: 'heading-id-attribute',
+            });
+
+            expect(wrapper.attributes().id).toBe('heading-id-attribute');
+        });
+
+        it(':id - should not have an `id` attribute if the prop is `null`', () => {
+            const wrapper = factoryShallowMount({
+                id: null,
+            });
+
+            expect(wrapper.attributes().id).toBe(undefined);
+        });
+
         it(':headingStyle - should accept and render the correct `headingStyle` class', () => {
             const wrapper = factoryShallowMount();
 

--- a/src/components/megalinks/Megalinks.vue
+++ b/src/components/megalinks/Megalinks.vue
@@ -21,6 +21,7 @@
                             heading-style="heading-xl"
                             class="vs-megalinks__heading"
                             data-test="vs-megalinks__heading"
+                            :id="sectionId"
                         >
                             {{ title }}
                         </VsHeading>
@@ -100,6 +101,14 @@ export default {
         * Title for the megalinks component
         */
         title: {
+            type: String,
+            required: false,
+            default: null,
+        },
+        /**
+        * ID for the section heading; can be used as anchor link
+        */
+        sectionId: {
             type: String,
             required: false,
             default: null,

--- a/src/components/megalinks/__tests__/Megalinks.jest.spec.js
+++ b/src/components/megalinks/__tests__/Megalinks.jest.spec.js
@@ -7,6 +7,7 @@ config.global.renderStubDefaultSlot = true;
 const factoryShallowMount = () => shallowMount(VsMegalinks, {
     propsData: {
         title: 'A megalinks title',
+        sectionId: 'a-megalinks-title',
         buttonLink: 'http://www.visitscotland.com',
         variant: 'multi-image',
     },
@@ -43,6 +44,15 @@ describe('VsMegalinks', () => {
                 title: '',
             });
             expect(wrapper.find('[data-test="vs-megalinks__intro"]').exists()).toBe(false);
+        });
+
+        it('should pass an id to the heading only if one is supplied', async() => {
+            expect(wrapper.find('[data-test="vs-megalinks__heading"]').attributes().id).toBe('a-megalinks-title');
+
+            await wrapper.setProps({
+                sectionId: null,
+            });
+            expect(wrapper.find('[data-test="vs-megalinks__heading"]').attributes().id).toBe(undefined);
         });
     });
 

--- a/stories/Heading.stories.js
+++ b/stories/Heading.stories.js
@@ -50,6 +50,7 @@ const base = {
     default: 'Welcome to Scotland',
     'sub-heading': '',
     level: 1,
+    id: 'welcome-to-scotland',
 };
 
 export const Default = Template.bind({

--- a/stories/MegalinksLinkList.stories.js
+++ b/stories/MegalinksLinkList.stories.js
@@ -52,6 +52,7 @@ const Template = (args) => ({
             :noJsMessage="args.noJsMessage"
             :noCookiesMessage="args.noCookiesMessage"
             :cookieLinkText="args.cookieLinkText"
+            :sectionId="args.sectionId"
         >
             <template v-slot:vs-megalinks-intro>
                 <p>{{ args.megalinksIntro }}</p>
@@ -121,6 +122,7 @@ const megalinksIntro = `From the rugged coastline to sparkling city lights,
 
 const base = {
     mainTitle: 'More inspiration for your next adventure',
+    sectionId: 'more-inspiration-for-your-next-adventure',
     buttonLink: '#',
     buttonText: 'Get more inspiration',
     megalinksIntro,


### PR DESCRIPTION
…onId` prop to VsMegalink

Heading frequently need an id attribute for things such as anchor links. Since any sectioning element should contain a heading tag we can now provide an id directly to the heading component