### PR TITLE
feat(skip to): add landmark id to hero section heading

### DIFF
--- a/src/components/hero-section/HeroSection.vue
+++ b/src/components/hero-section/HeroSection.vue
@@ -52,6 +52,7 @@
                         data-test="vs-hero-section__heading"
                         level="1"
                         heading-style="display-xs"
+                        id="main-heading"
                     >
                         <span v-html="heading" />
                     </VsHeading>


### PR DESCRIPTION
This id is currently present on the page intro but not the hero section, without it the skip doesn't point to page content properly