### PR TITLE
BSHUB-643 Accessibility MegaNav list items are not semantic

### DIFF
--- a/src/components/mega-nav/__tests__/meganav.jest.spec.js
+++ b/src/components/mega-nav/__tests__/meganav.jest.spec.js
@@ -19,7 +19,7 @@ function mountOptions(propsData) {
             ...propsData,
         },
         slots: {
-            'mega-nav-top-menu-items': '<li class="mega-nav-top-menu-items"></li>',
+            'mega-nav-top-menu-items': '<li class="mega-nav-top-menu-items" role="menuitem">menu item</li>',
         },
     };
 };

--- a/src/components/mega-nav/components/MegaNavDropdown.vue
+++ b/src/components/mega-nav/components/MegaNavDropdown.vue
@@ -2,6 +2,7 @@
     <div
         class="vs-mega-nav-dropdown"
         data-test="vs-mega-nav-dropdown"
+        role="menuitem"
     >
         <BDropdown
             variant="transparent"

--- a/src/components/mega-nav/components/MegaNavDropdownContainer.vue
+++ b/src/components/mega-nav/components/MegaNavDropdownContainer.vue
@@ -3,6 +3,7 @@
         class="vs-mega-nav-dropdown-container"
         data-test="vs-mega-nav-dropdown-container"
         ref="menuToggle"
+        role="presentation"
     >
         <LazyHydrationWrapper :on-interaction="['focus', 'click']">
             <VsMegaNavDropdown

--- a/src/components/mega-nav/components/MegaNavTopMenu.vue
+++ b/src/components/mega-nav/components/MegaNavTopMenu.vue
@@ -3,7 +3,7 @@
         unstyled
         class="vs-mega-nav-top-menu"
         data-test="vs-mega-nav-top-menu"
-        :role="isStatic ? 'menu' : null"
+        role="menubar"
     >
         <!-- @slot Default slot for top menu items -->
         <slot />


### PR DESCRIPTION
The accessibility issue on BSH was caused by a mixture of static and non-static menu items in the meganav. I've adjusted the aria roles so that they should now be correct when the meganav is static, non-static or mixed.