### PR TITLE
chore(storybook): add datawatcher addon back to storybook

### DIFF
--- a/.storybook/main.ts
+++ b/.storybook/main.ts
@@ -11,7 +11,8 @@ const config: StorybookConfig = {
     '@storybook/addon-links',
     '@chromatic-com/storybook',
     "@storybook/addon-a11y",
-    '@storybook/addon-docs'
+    '@storybook/addon-docs',
+    'storybook-addon-datalayer-watcher',
   ],
   framework: {
     name: '@storybook/vue3-vite',

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "speed-measure-webpack-plugin": "^1.5.0",
     "standard-version": "^9.5.0",
     "storybook": "^9.1.0-alpha.2",
+    "storybook-addon-datalayer-watcher": "^2.0.1",
     "style-loader": "^3.3.2",
     "svgo-loader": "^4.0.0",
     "theo": "^8.1.5",

--- a/yarn.lock
+++ b/yarn.lock
@@ -4291,6 +4291,7 @@ __metadata:
     speed-measure-webpack-plugin: "npm:^1.5.0"
     standard-version: "npm:^9.5.0"
     storybook: "npm:^9.1.0-alpha.2"
+    storybook-addon-datalayer-watcher: "npm:^2.0.1"
     style-loader: "npm:^3.3.2"
     svgo-loader: "npm:^4.0.0"
     theo: "npm:^8.1.5"
@@ -16006,6 +16007,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"react-inspector@npm:^6.0.2":
+  version: 6.0.2
+  resolution: "react-inspector@npm:6.0.2"
+  peerDependencies:
+    react: ^16.8.4 || ^17.0.0 || ^18.0.0
+  checksum: 10c0/8f9b23c21b4d95722e28c9455c2bf00fd9437347714382594461f98e5b9954d60864d0f4e74e881639b065e752a97ba52a65e39930c234072e5bff291bb02b5e
+  languageName: node
+  linkType: hard
+
 "react-is@npm:^16.13.1":
   version: 16.13.1
   resolution: "react-is@npm:16.13.1"
@@ -17509,6 +17519,18 @@ __metadata:
     es-errors: "npm:^1.3.0"
     internal-slot: "npm:^1.1.0"
   checksum: 10c0/de4e45706bb4c0354a4b1122a2b8cc45a639e86206807ce0baf390ee9218d3ef181923fa4d2b67443367c491aa255c5fbaa64bb74648e3c5b48299928af86c09
+  languageName: node
+  linkType: hard
+
+"storybook-addon-datalayer-watcher@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "storybook-addon-datalayer-watcher@npm:2.0.1"
+  dependencies:
+    lodash: "npm:^4.17.21"
+    react-inspector: "npm:^6.0.2"
+  peerDependencies:
+    storybook: ^9.0.0
+  checksum: 10c0/cb846f0b41487c17d832a0beb9b497fd843fe24d69dafc6b20b52ab664f079b3164400dc4c4b9e959ac410d5b3e0337284a9d6174b5479b41017f7383ad28053
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
This addon has been updated quite quickly so have added it back