### PR TITLE
feat(a11y): add status alert to hero section video controls

### DIFF
--- a/src/components/hero-section/HeroSection.vue
+++ b/src/components/hero-section/HeroSection.vue
@@ -74,6 +74,8 @@
                     v-if="videoSrc"
                     video-btn-text="Toggle video"
                     @video-toggled="onToggleVideo"
+                    :video-playing-status="videoPlayingStatus"
+                    :video-paused-status="videoPausedStatus"
                 >
                     {{ videoBtnText }}
                 </VsHeroSectionVideoControl>
@@ -105,6 +107,12 @@ export default {
         VsRichTextWrapper,
         VsHeroSectionImage,
         VsHeroSectionVideoControl,
+    },
+    provide() {
+        return {
+            videoPlayingStatus: this.videoPlayingStatus,
+            videoPausedStatus: this.videoPausedStatus,
+        };
     },
     props: {
         /**
@@ -176,6 +184,20 @@ export default {
         * The visually hidden text to display
         */
         videoBtnText: {
+            type: String,
+            default: '',
+        },
+        /**
+        * The aria alerted text to announce when the video is playing
+        */
+        videoPlayingStatus: {
+            type: String,
+            default: '',
+        },
+        /**
+        * The aria alerted text to announce when the video is paused
+        */
+        videoPausedStatus: {
             type: String,
             default: '',
         },

--- a/src/components/hero-section/components/HeroSectionVideoControl.vue
+++ b/src/components/hero-section/components/HeroSectionVideoControl.vue
@@ -9,6 +9,24 @@
         <!-- Slot for visiblly hidden screen reader text -->
         <slot />
     </VsButton>
+
+    <div
+        id="vs-hero-section-video-control__status"
+        aria-live="polite"
+        class="visually-hidden"
+        role="status"
+    >
+        <span
+            v-if="isPlaying && videoPlayingStatus"
+        >
+            {{ videoPlayingStatus }}
+        </span>
+        <span
+            v-if="!isPlaying && videoPausedStatus"
+        >
+            {{ videoPausedStatus }}
+        </span>
+    </div>
 </template>
 
 <script>
@@ -26,6 +44,14 @@ export default {
     release: '0.0.1',
     components: {
         VsButton,
+    },
+    inject: {
+        videoPlayingStatus: {
+            default: '',
+        },
+        videoPausedStatus: {
+            default: '',
+        },
     },
     emits: ['videoToggled'],
     data() {

--- a/stories/HeroSection.stories.js
+++ b/stories/HeroSection.stories.js
@@ -66,6 +66,8 @@ WithVideo.args = {
     src: 'fixtures/hero/images/lavendar-fields.jpg',
     videoSrc: 'fixtures/hero/video/lavendar-fields.mp4',
     videoBtnText: 'Play/pause background video',
+    videoPlayingStatus: 'Playing',
+    videoPausedStatus: 'Paused',
 };
 
 export const Inset = Template.bind({


### PR DESCRIPTION
A small accessibility requirement raised in https://visitscotland.atlassian.net/browse/VS-442 , interacting with the video play/pause button with the keyboard gave no feedback to a screen reader that anything was happening. This adds a toggling, aria-live announced label for its play/pause status if a label is provided