### PR TITLE
fix(css): remove css rules with syntax errors

### DIFF
--- a/src/components/event-card/EventCard.vue
+++ b/src/components/event-card/EventCard.vue
@@ -153,7 +153,6 @@ export default {
 
         .vs-event-card__date {
             text-align: right;
-            align-self: middle;
         }
 
         .vs-event-card__cta {

--- a/src/components/ski-scotland/ski-scotland-card/SkiScotlandCard.vue
+++ b/src/components/ski-scotland/ski-scotland-card/SkiScotlandCard.vue
@@ -586,10 +586,6 @@ export default {
         margin-bottom: $spacer-300;
         height: calc(100% - #{$spacer-300});
 
-        &::nth-last-child(-n + 3) {
-            margin-bottom: $spacer-0;
-        }
-
         .vs-ski-scotland-card__img-container {
             width: 100%;
             max-width: 100%;


### PR DESCRIPTION
These css rules are slightly incorrect (align-self takes center rather than middle and it should be a single : rather than :: for nth-child). While real browsers just sensibly ignore them and render around them, the browserstack visual testing tool Percy that QA use seems to have updated and now it completely crashes when it encounters any CSS errors which is very sensible I'm sure, but it's a blocker for the QA automation work Corina is looking at.

I'm just removing them for now as they aren't currently active - the event card date looks like it's positioned in the right place anyway and the ski cards are never not in the first 3 children because they're each contained within a separate VsCol - but give me a shout if there's a reason to keep either of them