### PR TITLE
Adjust VideoStore start timing in Stretched Link Card

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "third-party": "webpack --config ./build/third-party.webpack.conf.js",
     "commit": "cz",
     "prepare": "husky install",
-    "prepack": "yarn build:vite-no-theo",
+    "prepack": "yarn && yarn build",
     "release:patch": "standard-version --release-as patch",
     "release:minor": "standard-version --release-as minor",
     "release:major": "standard-version --release-as major"

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "third-party": "webpack --config ./build/third-party.webpack.conf.js",
     "commit": "cz",
     "prepare": "husky install",
-    "prepack": "yarn && yarn build",
+    "prepack": "yarn build:vite-no-theo",
     "release:patch": "standard-version --release-as patch",
     "release:minor": "standard-version --release-as minor",
     "release:major": "standard-version --release-as major"

--- a/src/components/stretched-link-card/StretchedLinkCard.vue
+++ b/src/components/stretched-link-card/StretchedLinkCard.vue
@@ -380,7 +380,11 @@ export default {
             return outputClasses;
         },
         videoDetails() {
-            return videoStore.videos[this.videoId];
+            if (videoStore) {
+                return videoStore.videos[this.videoId];
+            }
+
+            return null;
         },
         videoLoaded() {
             if (typeof this.videoDetails !== 'undefined' && this.videoDetails.videoDuration > 0) {

--- a/src/components/stretched-link-card/StretchedLinkCard.vue
+++ b/src/components/stretched-link-card/StretchedLinkCard.vue
@@ -387,7 +387,11 @@ export default {
             return null;
         },
         videoLoaded() {
-            if (typeof this.videoDetails !== 'undefined' && this.videoDetails.videoDuration > 0) {
+            if (
+                typeof this.videoDetails !== 'undefined'
+                && this.videoDetails !== null
+                && this.videoDetails.videoDuration > 0
+            ) {
                 return true;
             }
 

--- a/src/components/stretched-link-card/StretchedLinkCard.vue
+++ b/src/components/stretched-link-card/StretchedLinkCard.vue
@@ -192,6 +192,8 @@ import requiredCookiesData from '../../utils/required-cookies-data';
 
 const cookieValues = requiredCookiesData.youtube;
 
+let videoStore = null;
+
 /**
  * The Stretched Link Card is a block that stretches its nested link across its whole area
  * meaning that the whole block is clickable
@@ -341,12 +343,6 @@ export default {
             default: false,
         },
     },
-    setup() {
-        const videoStore = useVideoStore();
-        return {
-            videoStore,
-        };
-    },
     data() {
         return {
             jsDisabled: true,
@@ -384,7 +380,7 @@ export default {
             return outputClasses;
         },
         videoDetails() {
-            return this.videoStore.videos[this.videoId];
+            return videoStore.videos[this.videoId];
         },
         videoLoaded() {
             if (typeof this.videoDetails !== 'undefined' && this.videoDetails.videoDuration > 0) {
@@ -471,6 +467,8 @@ export default {
         },
     },
     mounted() {
+        videoStore = useVideoStore();
+
         // Checks whether js is disabled, to display an appropriate warning to the user
         this.jsDisabled = jsIsDisabled();
     },


### PR DESCRIPTION
Unclear what has changed exactly but since the v5 update the setup timing here is causing some issues in the Nuxt sites. It works fine in freemarker.com but that's a whole other beast anyway. Most of our components load the stores on mount instead of setup and it doesn't seem to have any impact on how it actually works for the user.