### PR TITLE
fix(footer social links): add aria label override functionality

### DIFF
--- a/src/components/footer/components/FooterSocialItem.vue
+++ b/src/components/footer/components/FooterSocialItem.vue
@@ -7,7 +7,7 @@
             data-test="vs-footer-social-item__link"
             :href="href"
             type="external"
-            :aria-label="icon"
+            :aria-label="ariaLabelOverride ? ariaLabelOverride : icon"
             data-layer-value="socialMediaExternalLinkDataEvent"
         >
             <VsIcon
@@ -55,6 +55,15 @@ export default {
         icon: {
             type: String,
             required: true,
+        },
+        /**
+         * Overrides the social icon name in the aria label for the component if provided,
+         * allowing specific or localised accessible text when it doesn't match up with the FA
+         * name for the brand.
+         */
+        ariaLabelOverride: {
+            type: String,
+            default: '',
         },
     },
 };

--- a/src/components/footer/components/__tests__/FooterSocialItem.jest.spec.js
+++ b/src/components/footer/components/__tests__/FooterSocialItem.jest.spec.js
@@ -25,19 +25,19 @@ describe('VsFooterSocialItem', () => {
 
     describe(':props', () => {
         it(':icon - Should show correct social icon', () => {
-            const icon = wrapper.find('[data-test="vs-footer-social-item__link"').find('vs-icon-stub');
+            const icon = wrapper.find('[data-test="vs-footer-social-item__link"]').find('vs-icon-stub');
 
             expect(icon.attributes('icon')).toBe('fab fa-facebook');
         });
 
         it(':href - Should show the correct social URL on the link', () => {
-            const link = wrapper.find('[data-test="vs-footer-social-item__link"');
+            const link = wrapper.find('[data-test="vs-footer-social-item__link"]');
 
             expect(link.attributes('href')).toBe('https://facebook.com');
         });
 
         it(':ariaLabelOverride - Should set the aria label if override provided', () => {
-            const link = wrapper.find('[data-test="vs-footer-social-item__link"');
+            const link = wrapper.find('[data-test="vs-footer-social-item__link"]');
 
             expect(link.attributes('aria-label')).toBe('Facebook');
         });

--- a/src/components/footer/components/__tests__/FooterSocialItem.jest.spec.js
+++ b/src/components/footer/components/__tests__/FooterSocialItem.jest.spec.js
@@ -8,7 +8,8 @@ const factoryShallowMount = (propsData) => shallowMount(VsFooterSocialItem, {
     propsData: {
         ...propsData,
         href: 'https://facebook.com',
-        icon: 'facebook',
+        icon: 'fab fa-facebook',
+        ariaLabelOverride: 'Facebook',
     },
 });
 
@@ -26,13 +27,19 @@ describe('VsFooterSocialItem', () => {
         it(':icon - Should show correct social icon', () => {
             const icon = wrapper.find('[data-test="vs-footer-social-item__link"').find('vs-icon-stub');
 
-            expect(icon.attributes('icon')).toBe('facebook');
+            expect(icon.attributes('icon')).toBe('fab fa-facebook');
         });
 
         it(':href - Should show the correct social URL on the link', () => {
             const link = wrapper.find('[data-test="vs-footer-social-item__link"');
 
             expect(link.attributes('href')).toBe('https://facebook.com');
+        });
+
+        it(':ariaLabelOverride - Should set the aria label if override provided', () => {
+            const link = wrapper.find('[data-test="vs-footer-social-item__link"');
+
+            expect(link.attributes('aria-label')).toBe('Facebook');
         });
     });
 });

--- a/stories/Footer.stories.js
+++ b/stories/Footer.stories.js
@@ -206,18 +206,22 @@ const Template = (args) => ({
                     <VsFooterSocialItem
                         href="#"
                         icon="fa-brands fa-facebook"
+                        aria-label-override="facebook"
                     />
                     <VsFooterSocialItem
                         href="#"
                         icon="fa-brands fa-x-twitter"
+                        aria-label-override="x"
                     />
                     <VsFooterSocialItem
                         href="#"
                         icon="fa-brands fa-youtube"
+                        aria-label-override="youtube"
                     />
                     <VsFooterSocialItem
                         href="#"
                         icon="fa-brands fa-instagram"
+                        aria-label-override="instagram"
                     />
                 </VsFooterSocialMenu>
             </template>


### PR DESCRIPTION
As we've switched to using the real fontawesome names for these icons, the default aria label has changed from "facebook link" to "fab fa-facebook link". This provides an option to set an override, and we can use the name of the social platform for that to return to the original more intuitive behaviour.

I thought we might be able to get away with just changing this by setting it in the website itself, but that sets a label on the li but not on the anchor, which doesn't work as expected unfortunately.