### PR TITLE
fix(sticky nav): add option for sticky nav with content

### DIFF
--- a/src/styles/_global-styles.scss
+++ b/src/styles/_global-styles.scss
@@ -31,6 +31,16 @@ hr {
         top: -36px;
     }
 
+    // If the global menu has text content, like a language menu, it is 6 pixels taller than the
+    // default and must be recessed more on scroll.
+    &--has-content {
+        top: -34px;
+
+        @include media-breakpoint-up(md) {
+            top: -42px;
+        }
+    }
+
     // If the skip to bar is focussed, stop trying to hide the global menu as this cuts the skip to
     // in half
     &:has(.vs-skip-to:focus-within) {


### PR DESCRIPTION
On .com, where we still have the language selector in the global menu, the purple bar is now slightly larger than it was before because of the typography changes in V5. When you scroll you're now left with a 6px purple strip at the top of the page that doesn't match the other sites. This adds a utility class that can be set alongside .vs-sticky-nav on any sites where the global menu actually contains content to ensure that the recess behaviour is as expected.