### PR TITLE
fix(search results): set font weight to ensure icon is visible

### DIFF
--- a/src/styles/third-party/_cludo-search-results.scss
+++ b/src/styles/third-party/_cludo-search-results.scss
@@ -209,6 +209,7 @@
                                 font-family: "Font Awesome 6 Pro";
                                 content: "\f061";
                                 color: $vs-color-icon-highlight;
+                                font-weight: $vs-font-weight-regular;
                                 font-size: $font-size-4;
                                 top: -4px;
                                 position: relative;


### PR DESCRIPTION
This arrow icon in search results is currently missing, because it's trying to retrieve it from the solid fontawesome set rather than the regular one. Setting this font weight ensures it looks to the correct set.

<img width="690" height="381" alt="image" src="https://github.com/user-attachments/assets/0afae5a1-5bd7-4c33-849f-b506f08fb4fd" />
