### PR TITLE
fix(civic): adjust cookie cats post civic scan

### DIFF
--- a/src/utils/required-cookies-data.js
+++ b/src/utils/required-cookies-data.js
@@ -1,11 +1,16 @@
-/**
- * 0 = Analytical
- * 1 = Marketing
- */
+export const cookieCategories = Object.freeze({
+    analytical: 0,
+    marketing: 1,
+});
 
 const cookieValues = {
-    youtube: [1],
-    embed: [0, 1],
+    youtube: [
+        cookieCategories.marketing,
+    ],
+    embed: [
+        cookieCategories.analytical,
+        cookieCategories.marketing,
+    ],
 };
 
 export default cookieValues;


### PR DESCRIPTION
Civic categories don't quite map to the onetrust ones, and it believes the youtube cookies are marketing