### PR TITLE
fix(breadcrumb): adjust breadcrumb sizing for larger share button on mobile

### DIFF
--- a/src/components/breadcrumb/components/BreadcrumbItem.vue
+++ b/src/components/breadcrumb/components/BreadcrumbItem.vue
@@ -95,7 +95,7 @@ export default {
         &:last-child,
         &:nth-last-child(2) {
             display: block;
-            max-width: 75%;
+            max-width: 65%;
             white-space: nowrap;
             overflow: hidden;
             text-overflow: ellipsis;

--- a/src/components/page-intro/PageIntro.vue
+++ b/src/components/page-intro/PageIntro.vue
@@ -14,7 +14,7 @@
                     :class="fullscreenMobile ? 'd-none-md' : ''"
                 >
                     <VsCol
-                        cols="10"
+                        cols="9"
                         :lg="heroIntro ? '8' : ''"
                         :offset-lg="heroIntro ? '1' : ''"
                     >


### PR DESCRIPTION
In the v5 update the share button and the spacers between each of the breadcrumb items got slightly larger, causing this overlap on mobile

<img width="412" height="111" alt="image" src="https://github.com/user-attachments/assets/8a5cb9e1-05bf-442b-ac8a-f33aaec86cb8" />

<img width="412" height="110" alt="image" src="https://github.com/user-attachments/assets/83bd69d6-7633-4f2e-929f-826084e173b0" />
