### PR TITLE
feat(codeowners): add codeowners file

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,17 @@
+# Configures "owners" for given types of code in the repo, automatically assigning them for review
+# when a PR is created
+
+# https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
+
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence.
+
+* @GemmaLouise @mjpvs @markup-mitchell @duncansanderson @chesterroberts-vs
+
+# Owners can also be set on a per-filetype basis, if that is useful in the future
+
+# *.vue @AVueDeveloper
+
+# Or to a folder
+
+# stories/ @AStoryWriter


### PR DESCRIPTION
This is an experimental change - in theory this file should configure github to automatically add reviewers to all PRs made to this repo. Currently they're all universal so it'll request a review from all FEDs for any PR in here, which is a tiny thing but it'll save a few seconds of searching. It could also be configured to request specific reviewers for certain filetypes of folders, which could be more useful for something like dot com where we'd want to separate it between front and back end code. The repo can then be configured to require a review from someone who is specifically a code owner for that filetype or folder, rather than just anyone.

Mostly this is just to save time adding the same 4 reviewers to every PR though :)