### PR TITLE
feat(video): add tabindex -1 to video source

### DIFF
--- a/src/components/video/components/VideoHtml5.vue
+++ b/src/components/video/components/VideoHtml5.vue
@@ -26,6 +26,7 @@
                 playsinline
                 :preload="lazyLoad ? 'none' : 'auto'"
                 :fetchpriority="lazyLoad ? 'low' : 'high'"
+                tabindex="-1"
             >
                 <source
                     :src="videoSrc"


### PR DESCRIPTION
For some reason firefox lets you tab to the video while chromium doesn't. That doesn't add anything accessibility wise because the actual tab target should be the play/pause toggle button which comes after the video itself.