### PR TITLE
feat(accordions): add additional analytics value for .com

### DIFF
--- a/src/mixins/dataLayerMixin.js
+++ b/src/mixins/dataLayerMixin.js
@@ -347,6 +347,7 @@ const dataLayerMixin = {
                     event: eventName,
                     tag_name: tagName,
                     accordion_text: event.accordion_text,
+                    click_text: event.accordion_text,
                 };
 
                 fullTemplate = this.compileFullTemplate(templateValues);

--- a/src/utils/data-layer-templates.js
+++ b/src/utils/data-layer-templates.js
@@ -350,6 +350,7 @@ const accordionOpenTemplate = [
     'tag_name',
     'meta_data',
     'accordion_text',
+    'click_text',
 ];
 
 const tabClickTemplate = [


### PR DESCRIPTION
We are apparently running out of custom dimensions in GA on .com so this can't listen to the accordion_text value, but click_text is a google builtin. The old one is staying for back compatibility on BSH