### PR TITLE
Add form functionality to support carbon calculator registration form

### DIFF
--- a/src/assets/fixtures/forms/text-block-form.json
+++ b/src/assets/fixtures/forms/text-block-form.json
@@ -1,0 +1,80 @@
+{
+    "formSandboxId": "90",
+    "formLiveId": "91",
+    "content": {
+        "heading": "What are your details?",
+        "successHeading": "What happens next?",
+        "successContent": "Since you've just joined us, we'll send you a couple of extra emails to introduce ourselves properly.",
+        "noJs": "<p><strong>You need JavaScript enabled to be able to display our newsletter subscription form.</strong></p>",
+        "submit": "Subscribe"
+    },
+    "fields": [
+        {
+            "name": "Email",
+            "element": "input",
+            "type": "email",
+            "label": "Email address",
+            "hint": "We'll only use this to email you our newsletter.",
+            "validation": {
+                "required": true,
+                "email": true
+            },
+            "validationMessages": {
+                "required": "Your email is required",
+                "email": "Please ensure your email is in the correct format"
+            }
+        },
+        {
+            "name": "Country",
+            "element": "select",
+            "countries": true,
+            "label": "Country",
+            "hint": "Telling us where you live helps us to email the most relevant content to you.",
+            "validation": {
+                "required": true
+            }
+        },
+        {
+            "name": "PostalCode",
+            "element": "input",
+            "type": "text",
+            "label": "Postcode",
+            "hint": "We'll only use this to email you local content and offers in our newsletter.",
+            "conditional": {
+                "Country": [
+                    "United Kingdom (Scotland)",
+                    "United Kingdom (England)",
+                    "United Kingdom (Wales)",
+                    "United Kingdom (Northern Ireland)"
+                ]
+            },
+            "validation": {
+                "postcode": true
+            },
+            "validationMessages": {
+                "postcode": "Please use a correct UK postcode"
+            }
+        },
+        {
+            "name": "conditionalText",
+            "element": "text-block",
+            "content": "<p>You've visited the UK before! Welcome back.</p>",
+            "conditional": {
+                "Country": [
+                    "United Kingdom (Scotland)",
+                    "United Kingdom (England)",
+                    "United Kingdom (Wales)",
+                    "United Kingdom (Northern Ireland)"
+                ]
+            }
+        },
+        {
+            "name": "termsNotice",
+            "element": "text-block",
+            "content": "<p>By submitting this form, you agree to our <a href=\"/terms\">terms and conditions</a> and <a href=\"/privacy\">privacy policy</a>.</p>"
+        }
+    ],
+    "submitConditional": {
+        "Email": []
+    }
+}

--- a/src/components/form/Form.vue
+++ b/src/components/form/Form.vue
@@ -163,6 +163,7 @@
                     variant="primary"
                     type="submit"
                     class="vs-form__submit mt-300"
+                    :disabled="submitDisabled"
                     @click="preSubmit"
                 >
                     {{ getTranslatedContent('submit') }}
@@ -386,6 +387,7 @@ export default {
             inputVal: '',
             reAlertErrors: false,
             emailFieldName: '',
+            submitDisabled: false,
         };
     },
     computed: {
@@ -813,6 +815,11 @@ export default {
          */
         preSubmit(e) {
             e.preventDefault();
+
+            if (this.submitDisabled) {
+                return;
+            }
+
             this.submitError = false;
 
             function isRequired(value) {
@@ -1023,6 +1030,8 @@ export default {
                     }
                 });
             });
+
+            this.checkSubmitConditional();
         },
         /**
          * Sets the 'd-none' class on conditional fields which are currently not displaying.
@@ -1031,6 +1040,38 @@ export default {
             return this.conditionalFields[fieldName] === true
                 || typeof this.conditionalFields[fieldName] === 'undefined'
                 ? '' : 'd-none';
+        },
+        /**
+         * Checks whether the submitConditional config meets its condition, and updates
+         * the submitDisabled flag. When the condition is met the submit button is disabled.
+         */
+        checkSubmitConditional() {
+            if (!this.formData.submitConditional) {
+                this.submitDisabled = false;
+
+                return;
+            }
+
+            let disable = false;
+
+            Object.keys(this.formData.submitConditional).forEach((rule) => {
+                const conditions = this.formData.submitConditional[rule];
+
+                if (Array.isArray(conditions)) {
+                    if (conditions.length === 0) {
+                        // Empty array means: enabled when field has any non-empty value
+                        if (!this.form[rule]) {
+                            disable = true;
+                        }
+                    } else if (conditions.indexOf(this.form[rule]) === -1) {
+                        disable = true;
+                    }
+                } else if (this.form[rule] !== conditions) {
+                    disable = true;
+                }
+            });
+
+            this.submitDisabled = disable;
         },
     },
 };

--- a/src/components/form/Form.vue
+++ b/src/components/form/Form.vue
@@ -140,6 +140,10 @@
                                         />
                                     </VsBody>
                                 </template>
+
+                                <template v-if="field.element === 'hr'">
+                                    <hr class="vs-form__hr" />
+                                </template>
                             </div>
                         </BFormGroup>
                     </template>
@@ -424,8 +428,9 @@ export default {
 
                     response.data.fields.forEach((field) => {
                         // create a data entry for each field, unless it is a text-block
-                        // which has no value and should not be submitted with the form
-                        if (field.element !== 'text-block') {
+                        // or hr which have no value and should not be submitted with the form
+                        if (field.element !== 'text-block'
+                            && field.element !== 'hr') {
                             this.form[field.name] = '';
                         }
 
@@ -803,7 +808,8 @@ export default {
             if (field.element === 'radio'
                 || field.element === 'submit'
                 || field.element === 'checkbox'
-                || field.element === 'text-block') {
+                || field.element === 'text-block'
+                || field.element === 'hr') {
                 return false;
             }
 

--- a/src/components/form/Form.vue
+++ b/src/components/form/Form.vue
@@ -1019,22 +1019,22 @@ export default {
                         // against the string
                         showField = false;
                     }
-
-                    if (showField) {
-                        if (!this.conditionalFields[field]) {
-                            this.conditionalFields[field] = true;
-
-                            if (this.$refs[field]) {
-                                this.$refs[field][0].manualValidate();
-                            }
-                        }
-                    } else {
-                        // If a field is hidden by its conditional status, clear any existing
-                        // errors as they are no longer relevant
-                        this.manageErrorStatus(field, []);
-                        this.conditionalFields[field] = false;
-                    }
                 });
+
+                if (showField) {
+                    if (!this.conditionalFields[field]) {
+                        this.conditionalFields[field] = true;
+
+                        if (this.$refs[field]) {
+                            this.$refs[field][0].manualValidate();
+                        }
+                    }
+                } else {
+                    // If a field is hidden by its conditional status, clear any existing
+                    // errors as they are no longer relevant
+                    this.manageErrorStatus(field, []);
+                    this.conditionalFields[field] = false;
+                }
             });
 
             this.checkSubmitConditional();

--- a/src/components/form/Form.vue
+++ b/src/components/form/Form.vue
@@ -134,7 +134,7 @@
                                 </template>
 
                                 <template v-if="field.element === 'text-block'">
-                                    <VsBody>
+                                    <VsBody aria-live="polite">
                                         <div
                                             v-html="getTranslatedTextBlockContent(field.name, index)"
                                         />

--- a/src/components/form/Form.vue
+++ b/src/components/form/Form.vue
@@ -132,6 +132,14 @@
                                         :rows="field.rows || null"
                                     />
                                 </template>
+
+                                <template v-if="field.element === 'text-block'">
+                                    <VsBody>
+                                        <div
+                                            v-html="getTranslatedTextBlockContent(field.name, index)"
+                                        />
+                                    </VsBody>
+                                </template>
                             </div>
                         </BFormGroup>
                     </template>
@@ -208,6 +216,7 @@ import VsButton from '@/components/button/Button.vue';
 import VsHeading from '@/components/heading/Heading.vue';
 import VsWarning from '@/components/warning/Warning.vue';
 import VsTextarea from '@/components/textarea/Textarea.vue';
+import VsBody from '@/components/body/Body.vue';
 import dataLayerMixin from '../../mixins/dataLayerMixin';
 
 /**
@@ -230,6 +239,7 @@ export default {
         VsHeading,
         VsWarning,
         VsTextarea,
+        VsBody,
     },
     mixins: [dataLayerMixin],
     props: {
@@ -411,8 +421,11 @@ export default {
                     }
 
                     response.data.fields.forEach((field) => {
-                        // create a data entry for each field
-                        this.form[field.name] = '';
+                        // create a data entry for each field, unless it is a text-block
+                        // which has no value and should not be submitted with the form
+                        if (field.element !== 'text-block') {
+                            this.form[field.name] = '';
+                        }
 
                         // Vue.set no longer needed to ensure reactivity in vue 3
                         if (field.conditional) {
@@ -538,6 +551,23 @@ export default {
             }
 
             return validationObj;
+        },
+        /**
+         * Attempts to retrieve the text block content for a given field from the current
+         * language obj. If no localisation is available, or the language is en, falls back
+         * to the default content for the fieldname.
+         */
+        getTranslatedTextBlockContent(fieldName, index) {
+            const languageObj = this.getLanguageObj();
+
+            if (this.language !== 'en'
+                && !this.isUndefined(languageObj[fieldName])
+                && !this.isUndefined(languageObj[fieldName].content)
+            ) {
+                return languageObj[fieldName].content;
+            }
+
+            return this.formData.fields[index].content;
         },
         /**
          * Attempts to retrieve the options for a given select field from the current language
@@ -770,7 +800,8 @@ export default {
         needsLabel(field) {
             if (field.element === 'radio'
                 || field.element === 'submit'
-                || field.element === 'checkbox') {
+                || field.element === 'checkbox'
+                || field.element === 'text-block') {
                 return false;
             }
 

--- a/src/components/form/__tests__/Form.jest.spec.js
+++ b/src/components/form/__tests__/Form.jest.spec.js
@@ -71,6 +71,11 @@ const formData = {
                 selectexample: 'first',
             },
         },
+        {
+            name: 'termsNotice',
+            element: 'text-block',
+            content: '<p>By submitting this form, you agree to our <a href="/terms">terms and conditions</a>.</p>',
+        },
     ],
     de: {
         FirstName: {
@@ -183,7 +188,7 @@ describe('VsForm', () => {
 
         const allInputs = wrapper.findAll('b-form-group-stub');
 
-        expect(allInputs.length).toBe(4);
+        expect(allInputs.length).toBe(5);
     });
 
     it('should render a submit element with a value of `submit` from the data', async() => {
@@ -218,6 +223,23 @@ describe('VsForm', () => {
 
         const recaptcha = wrapper.find('vs-recaptcha-stub');
         expect(recaptcha.exists()).toBe(false);
+    });
+
+    it('should render a text-block field with its content', async() => {
+        const wrapper = factoryShallowMount();
+        await wrapper.vm.$nextTick();
+
+        const textBlock = wrapper.find('vs-body-stub');
+
+        expect(textBlock.exists()).toBe(true);
+        expect(textBlock.html()).toContain('terms and conditions');
+    });
+
+    it('should not add a text-block field to the form data object', async() => {
+        const wrapper = factoryShallowMount();
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.vm.form.termsNotice).toBeUndefined();
     });
 
     describe(':slots', () => {

--- a/src/components/form/__tests__/Form.jest.spec.js
+++ b/src/components/form/__tests__/Form.jest.spec.js
@@ -76,6 +76,10 @@ const formData = {
             element: 'text-block',
             content: '<p>By submitting this form, you agree to our <a href="/terms">terms and conditions</a>.</p>',
         },
+        {
+            name: 'formSeparator',
+            element: 'hr',
+        },
     ],
     de: {
         FirstName: {
@@ -188,7 +192,7 @@ describe('VsForm', () => {
 
         const allInputs = wrapper.findAll('b-form-group-stub');
 
-        expect(allInputs.length).toBe(5);
+        expect(allInputs.length).toBe(6);
     });
 
     it('should render a submit element with a value of `submit` from the data', async() => {
@@ -240,6 +244,22 @@ describe('VsForm', () => {
         await wrapper.vm.$nextTick();
 
         expect(wrapper.vm.form.termsNotice).toBeUndefined();
+    });
+
+    it('should render an hr element for hr fields', async() => {
+        const wrapper = factoryShallowMount();
+        await wrapper.vm.$nextTick();
+
+        const hr = wrapper.find('.vs-form__hr');
+
+        expect(hr.exists()).toBe(true);
+    });
+
+    it('should not add an hr field to the form data object', async() => {
+        const wrapper = factoryShallowMount();
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.vm.form.formSeparator).toBeUndefined();
     });
 
     it('should disable the submit button when submitConditional condition is not met', async() => {

--- a/src/components/form/__tests__/Form.jest.spec.js
+++ b/src/components/form/__tests__/Form.jest.spec.js
@@ -242,6 +242,128 @@ describe('VsForm', () => {
         expect(wrapper.vm.form.termsNotice).toBeUndefined();
     });
 
+    it('should disable the submit button when submitConditional condition is not met', async() => {
+        const wrapper = factoryShallowMount();
+        await wrapper.vm.$nextTick();
+
+        wrapper.setData({
+            formData: {
+                ...wrapper.vm.formData,
+                submitConditional: {
+                    selectexample: 'first',
+                },
+            },
+        });
+
+        wrapper.vm.updateFieldData({
+            field: 'selectexample',
+            value: 'second',
+            errors: [],
+        });
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.vm.submitDisabled).toBe(true);
+    });
+
+    it('should enable the submit button when submitConditional condition is met', async() => {
+        const wrapper = factoryShallowMount();
+        await wrapper.vm.$nextTick();
+
+        wrapper.setData({
+            formData: {
+                ...wrapper.vm.formData,
+                submitConditional: {
+                    selectexample: 'first',
+                },
+            },
+        });
+
+        wrapper.vm.updateFieldData({
+            field: 'selectexample',
+            value: 'first',
+            errors: [],
+        });
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.vm.submitDisabled).toBe(false);
+    });
+
+    it('should disable the submit button when an empty-array submitConditional field has no value', async() => {
+        const wrapper = factoryShallowMount();
+        await wrapper.vm.$nextTick();
+
+        wrapper.setData({
+            formData: {
+                ...wrapper.vm.formData,
+                submitConditional: {
+                    Email: [],
+                },
+            },
+        });
+
+        wrapper.vm.checkSubmitConditional();
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.vm.submitDisabled).toBe(true);
+    });
+
+    it('should enable the submit button when an empty-array submitConditional field has a value', async() => {
+        const wrapper = factoryShallowMount();
+        await wrapper.vm.$nextTick();
+
+        wrapper.setData({
+            formData: {
+                ...wrapper.vm.formData,
+                submitConditional: {
+                    Email: [],
+                },
+            },
+        });
+
+        wrapper.vm.updateFieldData({
+            field: 'Email',
+            value: 'test@example.com',
+            errors: [],
+        });
+        await wrapper.vm.$nextTick();
+
+        expect(wrapper.vm.submitDisabled).toBe(false);
+    });
+
+    it('should not submit the form when submit is disabled', async() => {
+        const axiosSpy = jest.spyOn(VsForm.methods, 'axiosSubmit');
+
+        const wrapper = factoryMount({
+            isMarketo: false,
+            submitUrl: '/test/form/url',
+            isTest: true,
+        });
+
+        wrapper.setData({
+            submitDisabled: true,
+        });
+        await wrapper.vm.$nextTick();
+
+        const fnInput = wrapper.find('#FirstName');
+        await fnInput.setValue('Jason');
+
+        const lnInput = wrapper.find('#LastName');
+        await lnInput.setValue('Bourne');
+
+        const eInput = wrapper.find('#Email');
+        await eInput.setValue('test@email.com');
+
+        wrapper.setData({
+            recaptchaVerified: true,
+        });
+        await wrapper.vm.$nextTick();
+
+        wrapper.find('.vs-form__submit').trigger('click');
+        await wrapper.vm.$nextTick();
+
+        expect(axiosSpy).not.toHaveBeenCalled();
+    });
+
     describe(':slots', () => {
         it('should render the `submitting` slot', async() => {
             const wrapper = factoryShallowMount();

--- a/stories/components/Form.stories.js
+++ b/stories/components/Form.stories.js
@@ -1,5 +1,5 @@
 import {
-    userEvent, within, waitFor,
+    userEvent, within, waitFor, expect,
 } from 'storybook/test';
 
 import VsForm from '@/components/form/Form.vue';
@@ -187,5 +187,40 @@ TextBlockConditional.play = async({ canvasElement }) => {
     await waitFor(async() => {
         const select = canvas.getByLabelText('Country');
         await userEvent.selectOptions(select, ['United Kingdom (Scotland)']);
+    });
+};
+
+export const ConditionalSubmit = Template.bind({
+});
+
+ConditionalSubmit.args = {
+    ...base,
+    usesRecaptcha: false,
+    dataUrl: './fixtures/forms/text-block-form.json',
+};
+
+ConditionalSubmit.play = async({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(() => {
+        const submit = canvas.getByText('Subscribe');
+        expect(submit.closest('button')).toBeDisabled();
+    }, {
+        timeout: 15000,
+        interval: 250,
+    });
+
+    await waitFor(async() => {
+        const email = canvas.getByLabelText('Email address');
+        await userEvent.type(email, 'test@example.com');
+        email.blur();
+    });
+
+    await waitFor(() => {
+        const submit = canvas.getByText('Subscribe');
+        expect(submit.closest('button')).toBeEnabled();
+    }, {
+        timeout: 15000,
+        interval: 250,
     });
 };

--- a/stories/components/Form.stories.js
+++ b/stories/components/Form.stories.js
@@ -162,3 +162,30 @@ NoJavascript.args = {
     ...base,
     jsDisabled: true,
 };
+
+export const TextBlock = Template.bind({
+});
+
+TextBlock.args = {
+    ...base,
+    usesRecaptcha: false,
+    dataUrl: './fixtures/forms/text-block-form.json',
+};
+
+export const TextBlockConditional = Template.bind({
+});
+
+TextBlockConditional.args = {
+    ...base,
+    usesRecaptcha: false,
+    dataUrl: './fixtures/forms/text-block-form.json',
+};
+
+TextBlockConditional.play = async({ canvasElement }) => {
+    const canvas = within(canvasElement);
+
+    await waitFor(async() => {
+        const select = canvas.getByLabelText('Country');
+        await userEvent.selectOptions(select, ['United Kingdom (Scotland)']);
+    });
+};


### PR DESCRIPTION
This adds a couple of bits of form functionality to support the new carbon calculator registration form, as well as potential future forms. The form opens with some qualifying questions and if the user says no to any of them they can't complete the rest of the form or register (is your business actually in Scotland etc etc). This adds:

* HTML text blocks configured through the form json config so we can conditionally show them an explanatory message if they can't proceed
* HRs configured through the form config to separate the qualifying section from the main copy of the form
* The ability to disable form submissions until a condition is met (using the same syntax/logic as conditional fields), as a submission is not meaningful until those 3 questions are passed and most of the required fields only appear after that.