### PR TITLE
give tabindex to VsTabs; remove active attribute in story

### DIFF
--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -8,6 +8,7 @@ NEW
         <BTabs
             :no-container="noContainer"
             :align="noContainer ? 'center' : null"
+            v-model:index="tabIndex"
         >
             <!-- @slot default slot for VsTabItems -->
             <slot />
@@ -17,7 +18,7 @@ NEW
 
 <script>
 import { BTabs } from 'bootstrap-vue-next';
-import { computed } from 'vue';
+import { computed, ref } from 'vue';
 /**
  * Tabs wrapper used with TabItems.
  *
@@ -49,6 +50,11 @@ export default {
             type: Boolean,
             default: false,
         },
+    },
+    data() {
+        return {
+            tabIndex: ref(0),
+        };
     },
 };
 </script>

--- a/src/components/tabs/Tabs.vue
+++ b/src/components/tabs/Tabs.vue
@@ -18,7 +18,7 @@ NEW
 
 <script>
 import { BTabs } from 'bootstrap-vue-next';
-import { computed, ref } from 'vue';
+import { computed } from 'vue';
 /**
  * Tabs wrapper used with TabItems.
  *
@@ -53,7 +53,7 @@ export default {
     },
     data() {
         return {
-            tabIndex: ref(0),
+            tabIndex: 0,
         };
     },
 };

--- a/stories/components/Tabs.stories.js
+++ b/stories/components/Tabs.stories.js
@@ -35,7 +35,6 @@ const Template = (args) => ({
             <VsTabs v-bind="args">
                 <VsTabItem 
                     title="Getting Here"
-                    active
                 >
                     <div class="px-125 py-100">
                         <p>


### PR DESCRIPTION
https://github.com/visitscotland/business-support-hub-front-end/pull/238 attempts to configure the component instance in the product to initialise the page with an open tab, but it stops the other tabs working. I'll close that PR.

This PR moves the fix upstream to the library component, adding the prescribed usage of Bootstrap Vue Next's `BTabs` component to the `Vs` wrapper. 

https://bootstrap-vue-next.github.io/bootstrap-vue-next/docs/components/tabs.html#programmatically-activating-and-deactivating-tabs
